### PR TITLE
update add remote appengine provider to use new bucket format

### DIFF
--- a/scripts/remote-project-onboarding/add-remote-appengine.sh
+++ b/scripts/remote-project-onboarding/add-remote-appengine.sh
@@ -3,18 +3,16 @@
 # set -x
 shopt -s extglob
 
-
 ## variables that will change for each target
 # Change this to match the specific onboarding bucket name for your project
 ONBOARDING_BUCKET_NAME="np-platforms-cd-thd-spinnaker-onboarding"
 ## TODO: what can we do to automate the gathering of these variables?
-PROJECT=""
-GROUP=""
+GROUP="gg_cloud_gcp_np-platforms-cd_dev"
 declare -A selected_groups=()
 selected_groups[$GROUP]="$GROUP"
 
 ####################################################
-########             Dependencies           ######## 
+########             Dependencies           ########
 ####################################################
 
 # ensure that the required commands are present needed to run this script
@@ -36,11 +34,53 @@ JSON_FILE_PATH="/spinnaker/accounts"
 echo "-----------------------------------------------------------------------------"
 echo " *****   GAE Onboarding Target   ***** "
 
-targets=()
-for value in $(gsutil ls "$ONBOARDING_BUCKET" 2>/dev/null)
+projects=()
+for proj in $(gsutil ls "$ONBOARDING_BUCKET" 2>/dev/null)
 do
-    if [[ $value != "$ONBOARDING_BUCKET" ]]; then
-        targets+=(${value/$ONBOARDING_BUCKET/})
+    if [[ $proj != "$ONBOARDING_BUCKET" ]]; then
+        project=${proj/$ONBOARDING_BUCKET/}
+        # Remove the forward slash suffix from the project for legibility.
+        projects+=(${project:0:-1})
+    fi
+done
+
+if [ ${#projects[@]} == 0 ]; then
+    printf "\nNo projects found to onboard.\n"
+    exit 0
+fi
+
+PS3="-----------------------------------------------------------------------------"$'\n'"Enter the number for the project to setup within Spinnaker : ";
+select project in "${projects[@]}"
+do
+    if [ "$project" == "" ]; then
+        echo "You must select a Project to onboard"
+    else
+        cat ~/.hal/config | grep "$project" >/dev/null 2>&1
+        if [ "$?" -eq 0 ]; then
+            echo "-----------------------------------------------------------------------------"
+            echo "The selected onboarding GAE project appears to already be in the halyard config file : "
+            echo "-----------------------------------------------------------------------------"
+            cat ~/.hal/config | grep "$project" -C 5
+            echo "-----------------------------------------------------------------------------"
+            echo "You almost certainly don't want it added again so cowardly exiting onboarding"
+            exit 1;
+        else
+            PROJECT="$project"
+            SELECTED_PROJECT_ONBOARDING_BUCKET="$ONBOARDING_BUCKET""$project"
+            break;
+        fi
+    fi
+done
+
+targets=()
+for value in $(gsutil ls "$SELECTED_PROJECT_ONBOARDING_BUCKET" 2>/dev/null)
+do
+    if [[ $value != "$SELECTED_PROJECT_ONBOARDING_BUCKET" ]]; then
+        file=${value/$SELECTED_PROJECT_ONBOARDING_BUCKET/}
+        if [[ "$file" != "sa.json" ]]; then
+            # Remove the forward slash prefix from the file for legibility.
+            targets+=(${file:1})
+        fi
     fi
 done
 PS3="-----------------------------------------------------------------------------"$'\n'"Enter the number for the GAE target to setup within Spinnaker : ";
@@ -49,41 +89,32 @@ do
     if [ "$target" == "" ]; then
         echo "You must select a GAE Target to onboard"
     else
-        cat ~/.hal/config | grep "$target" >/dev/null 2>&1
-        if [ "$?" -eq 0 ]; then
-            echo "-----------------------------------------------------------------------------"
-            echo "The selected onboarding GAE Target appears to already be in the halyard config file : "
-            echo "-----------------------------------------------------------------------------"
-            cat ~/.hal/config | grep "$target" -C 5
-            echo "-----------------------------------------------------------------------------"
-            echo "You almost certainly don't want it added again so cowardly exiting onboarding"
-            exit 1;
-        else
-            echo "-----------------------------------------------------------------------------"
-            echo "GAE Target $target selected"
-            JSON_FILE="$target"
-            break;
-        fi
+        echo "-----------------------------------------------------------------------------"
+        echo "GAE Target $target selected"
+        JSON_FILE="$target"
+        break;
     fi
 done
 
 JSON_FULL_PATH="$JSON_FILE_PATH/$JSON_FILE"
-echo "getting json file ($JSON_FILE) from bucket"
+echo "getting json file ($JSON_FILE) from bucket for project $PROJECT"
 
-gsutil cp "${ONBOARDING_BUCKET}${JSON_FILE}" "$JSON_FULL_PATH"
+REMOTE_JSON_FULL_PATH="${ONBOARDING_BUCKET}${PROJECT}/${JSON_FILE}"
+gsutil cp "$REMOTE_JSON_FULL_PATH" "$JSON_FULL_PATH"
 
 BASENAME=$(basename -s '.json' "$JSON_FULL_PATH")
 
-# The below will replace any number of characters inside the square brackets with a dash 
+# The below will replace any number of characters inside the square brackets with a dash
 SANITIZED_NAME=${BASENAME//+([_])/-}
 echo "Sanitized provider name: $SANITIZED_NAME"
 
-if [[ -z "$GROUP" ]] || [[ -z "$PROJECT" ]]; then
-    echo "Both GROUP and PROJECT must be set (see top of this script), cannot continue!"
+if [ "$GROUP" == "" ]; then
+    echo "GROUP must be set (see top of this script), cannot continue!"
     exit 1
 fi
 
-gsutil mv "${ONBOARDING_BUCKET}${JSON_FILE}" "${ONBOARDING_BUCKET_COMPLETE}${JSON_FILE}"
+# Move the target file to completed.
+gsutil mv "$REMOTE_JSON_FULL_PATH" "${ONBOARDING_BUCKET_COMPLETE}${JSON_FILE}"
 
 echo "adding new appengine provider for $BASENAME"
 
@@ -96,8 +127,8 @@ hal config provider appengine account add "$SANITIZED_NAME" \
 echo "status code of adding account $?"
 
 #close down connection to fiat & front50 if they already exists
-fuser -k 7003/tcp >/dev/null 2>&1; fuser -k 8080/tcp  >/dev/null 2>&1
- 
+fuser -k 7003/tcp >/dev/null 2>&1; fuser -k 8080/tcp >/dev/null 2>&1
+
 echo "patching fiat to add serice account for groups"
 kubectl port-forward service/spin-front50 8080:8080 -n spinnaker >/dev/null 2>&1 &
 while [ -z "$FRONT50_UP_PID" ]; do
@@ -129,4 +160,7 @@ done
 # force fiat to sync the change
 curl -X POST "$FIAT"/roles/sync
 
+printf "\n"
+
 fuser -k 8080/tcp >/dev/null 2>&1; fuser -k 7003/tcp >/dev/null 2>&1
+


### PR DESCRIPTION
1) Loop through onboarding projects under `ONBOARDING_BUCKET_NAME/gae` and allow choice of which project to onboard. Fail if no projects are found to onboard.
2) Loop though target providers under `ONBOARDING_BUCKET_NAME/gae/PROJECT_ID` and allow choice of target provider to onboard.
3) Continue with normal onboarding process.