### PR TITLE
Fix failure to destroy namespace

### DIFF
--- a/spinnaker/modules/k8s-service-account/k8s-service-account.tf
+++ b/spinnaker/modules/k8s-service-account/k8s-service-account.tf
@@ -62,3 +62,16 @@ resource "google_storage_bucket_object" "spinnaker_kubeconfig_file" {
   bucket       = var.bucket_name
   content_type = "application/text"
 }
+
+resource "kubernetes_secret" "secret" {
+  count       = var.enable ? 1 : 0
+
+  metadata {
+    name      = "cloudsql-instance-credentials"
+    namespace = var.spinnaker_namespace
+  }
+
+  data = {
+    secret = base64decode(var.cloudsql_credentials)
+  }
+}

--- a/spinnaker/modules/k8s-service-account/vars.tf
+++ b/spinnaker/modules/k8s-service-account/vars.tf
@@ -49,3 +49,12 @@ variable "enable" {
   default     = false
 }
 
+variable "spinnaker_namespace" {
+  type         = "string"
+  description  = "namespace where spinnaker lives"
+}
+
+variable "cloudsql_credentials" {
+  type         = string
+  description  = "cloudsql instance service account credentials in json format"
+}

--- a/spinnaker/vars.tf
+++ b/spinnaker/vars.tf
@@ -113,6 +113,13 @@ variable "default_client_certificate_config" {
   ]
 }
 
+variable "default_create_namespace" {
+  description = "The default namespace in which to create spinnaker kubernetes resources"
+  type        = string
+  
+  default     = "spinnaker"
+}
+
 variable "extras" {
   type        = map(string)
   description = "Extra options to configure K8s. These are options that are unlikely to change from deployment to deployment. All options must be specified when passed as a map variable input to this module."


### PR DESCRIPTION
This corrects a problem found when destroying spingo in which the namespace couldn't be destroyed because the cluster was being destroyed simultaneously

The namespace creation was moved inside the gke cluster creation module (https://github.com/devorbitus/terraform-google-gke-infra) where it could be configured to depend on the node pool so its created after, and destroyed before, the cluster/node pool

This allowed us to move the creation of the cloudsql instance service account credentials secret back into the k8s-service-accounts module