### PR TITLE
add local IP to k8s auth nodes list

### DIFF
--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -75,7 +75,7 @@ module "k8s" {
   region          = var.cluster_region
   private_cluster = true # This will disable public IPs from the nodes
 
-  networks_that_can_access_k8s_api = compact(flatten([var.default_networks_that_can_access_k8s_api, [formatlist("%s/32", data.google_compute_address.halyard_ip_address.address)]]))
+  networks_that_can_access_k8s_api = compact(flatten([var.default_networks_that_can_access_k8s_api, [formatlist("%s/32", [data.http.local_outgoing_ip_address.body])], [formatlist("%s/32", data.google_compute_address.halyard_ip_address.address)]]))
 
   oauth_scopes              = var.default_oauth_scopes
   k8s_options               = var.default_k8s_options
@@ -94,7 +94,7 @@ module "k8s-sandbox" {
   region          = var.cluster_region
   private_cluster = true # This will disable public IPs from the nodes
 
-  networks_that_can_access_k8s_api = compact(flatten([var.default_networks_that_can_access_k8s_api, [formatlist("%s/32", data.google_compute_address.halyard_ip_address.address)]]))
+  networks_that_can_access_k8s_api = compact(flatten([var.default_networks_that_can_access_k8s_api, [formatlist("%s/32", [data.http.local_outgoing_ip_address.body])], [formatlist("%s/32", data.google_compute_address.halyard_ip_address.address)]]))
 
   oauth_scopes              = var.default_oauth_scopes
   k8s_options               = var.default_k8s_options
@@ -211,6 +211,10 @@ resource "google_storage_bucket_object" "fiat_service_account_key_storage" {
 
 data "google_compute_address" "halyard_ip_address" {
   name = "halyard-external-ip"
+}
+
+data "http" "local_outgoing_ip_address" {
+  url = "https://ifconfig.co"
 }
 
 data "google_compute_address" "ui_ip_address" {


### PR DESCRIPTION
You cannot modify clusters that you can't access so we need to make sure you can access them when running from more dynamic environments like google cloud shell