### PR TITLE
Add tf ci GitHub actions

### DIFF
--- a/.github/workflows/pull-req-workflow.yaml
+++ b/.github/workflows/pull-req-workflow.yaml
@@ -1,0 +1,136 @@
+name: 'Spingo Terraform Validation'
+on:
+  - pull_request
+jobs:
+  static-ips:
+    name: 'Terraform (Static IPs)'
+    services:
+      vault:
+        image: vault
+        ports:
+          - 8200:8200
+        env:
+          VAULT_DEV_ROOT_TOKEN_ID: jeremy
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: 'static_ips'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Terraform Validate'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'validate'
+          tf_actions_working_dir: 'static_ips'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VAULT_ADDR: http://localhost:8200
+          VAULT_TOKEN: jeremy
+  dns:
+    name: 'Terraform (DNS)'
+    services:
+      vault:
+        image: vault
+        ports:
+          - 8200:8200
+        env:
+          VAULT_DEV_ROOT_TOKEN_ID: jeremy
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: 'dns'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Terraform Validate'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'validate'
+          tf_actions_working_dir: 'dns'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VAULT_ADDR: http://localhost:8200
+          VAULT_TOKEN: jeremy
+  spinnaker:
+    name: 'Terraform (Spinnaker)'
+    services:
+      vault:
+        image: vault
+        ports:
+          - 8200:8200
+        env:
+          VAULT_DEV_ROOT_TOKEN_ID: jeremy
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: 'spinnaker'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Terraform Validate'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'validate'
+          tf_actions_working_dir: 'spinnaker'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VAULT_ADDR: http://localhost:8200
+          VAULT_TOKEN: jeremy
+  halyard:
+    name: 'Terraform (Halyard)'
+    services:
+      vault:
+        image: vault
+        ports:
+          - 8200:8200
+        env:
+          VAULT_DEV_ROOT_TOKEN_ID: jeremy
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@master
+      - name: 'Terraform Init'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'init'
+          tf_actions_working_dir: 'halyard'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: 'Terraform Validate'
+        uses: hashicorp/terraform-github-actions@master
+        with:
+          tf_actions_version: 0.12.13
+          tf_actions_subcommand: 'validate'
+          tf_actions_working_dir: 'halyard'
+          tf_actions_comment: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VAULT_ADDR: http://localhost:8200
+          VAULT_TOKEN: jeremy

--- a/dns/dns.tf
+++ b/dns/dns.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "gcs" {
-  }
-}
 
 provider "vault" {
 }

--- a/dns/dns.tf
+++ b/dns/dns.tf
@@ -1,4 +1,3 @@
-
 provider "vault" {
 }
 

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -1,5 +1,3 @@
-
-
 variable "gcp_project" {
   description = "GCP project name"
 }

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -1,7 +1,4 @@
-terraform {
-  backend "gcs" {
-  }
-}
+
 
 variable "gcp_project" {
   description = "GCP project name"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "gcs" {
-  }
-}
 
 provider "vault" {
 }

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -1,4 +1,3 @@
-
 provider "vault" {
 }
 

--- a/static_ips/static_ips.tf
+++ b/static_ips/static_ips.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "gcs" {
-  }
-}
 
 provider "vault" {
 }

--- a/static_ips/static_ips.tf
+++ b/static_ips/static_ips.tf
@@ -1,4 +1,3 @@
-
 provider "vault" {
 }
 


### PR DESCRIPTION
When PR #54 was created there was an error that was picked up only after the merge that CI could have found (PR #55). This PR adds a github action job per terraform directory to initialize and validate which can be added to branch protection to make sure only validated terraform gets merged. This will not stop errors that occur because of remote data not being what is expected but should help find 80-ish% or more of the issues.

We had to remove the empty terraform backend blocks that reference Google Cloud Storage because the GitHub Actions validation will be run within the docker image and are not needed anyway as the `initial_start.sh` script creates `override.tf` files per directory that replace the entire block anyway.

Fixes #3 