### PR TITLE
Add second cluster

### DIFF
--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -73,6 +73,7 @@ GATE_LOCAL
 
 tee /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/redis.yml << REDIS
 overrideBaseUrl: redis://${SPIN_REDIS_ADDR}
+skipLifeCycleManagement: true
 REDIS
 
 # set-up orca to use cloudsql proxy

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -218,8 +218,8 @@ module "k8s-spinnaker-agent" {
   oauth_scopes              = var.default_oauth_scopes
   k8s_options               = var.default_k8s_options
   node_metadata             = var.default_node_metadata
-  node_options              = var.second_clsuter_node_options
-  node_pool_options         = var.second_clsuter_node_pool_options
+  node_options              = var.second_cluster_node_options
+  node_pool_options         = var.second_cluster_node_pool_options
   client_certificate_config = var.default_client_certificate_config
   cloud_nat                 = false                                                 # Will re-use the cloud nat created by the primary cluster
   node_tags                 = ["${var.cluster_config["0"]}-${var.cluster_region}"]  # Use the same network tags as primary cluster
@@ -270,8 +270,8 @@ module "k8s-sandbox-agent" {
   oauth_scopes              = var.default_oauth_scopes
   k8s_options               = var.default_k8s_options
   node_metadata             = var.default_node_metadata
-  node_options              = var.second_clsuter_node_options
-  node_pool_options         = var.second_clsuter_node_pool_options
+  node_options              = var.second_cluster_node_options
+  node_pool_options         = var.second_cluster_node_pool_options
   client_certificate_config = var.default_client_certificate_config
   cloud_nat                 = false                                                 # Will re-use the cloud nat created by the primary cluster
   node_tags                 = ["${var.cluster_config["1"]}-${var.cluster_region}"]  # Use the same network tags as primary cluster

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -225,6 +225,7 @@ module "k8s-spinnaker-agent" {
   node_tags                 = ["${var.cluster_config["0"]}-${var.cluster_region}"]  # Use the same network tags as primary cluster
   create_namespace          = var.default_create_namespace
   extras                    = var.extras
+  crypto_key_id             = lookup(module.gke_keys.crypto_key_id_map, "${var.cluster_config["0"]}-${var.cluster_region}", "")
 }
 
 provider "kubernetes" {
@@ -276,6 +277,7 @@ module "k8s-sandbox-agent" {
   node_tags                 = ["${var.cluster_config["1"]}-${var.cluster_region}"]  # Use the same network tags as primary cluster
   create_namespace          = var.default_create_namespace
   extras                    = var.extras
+  crypto_key_id             = lookup(module.gke_keys.crypto_key_id_map, "${var.cluster_config["1"]}-${var.cluster_region}", "")
 }
 
 provider "kubernetes" {

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -64,6 +64,15 @@ variable "cluster_config" {
   }
 }
 
+variable "agent_cluster_config" {
+  description = "This variable has been placed above the module declaration to facilitate easy changes between projects. The first index should always be the main cluster"
+
+  default = {
+    "0" = "spinnaker-agent"
+    "1" = "sandbox-agent"
+  }
+}
+
 variable "hostname_config" {
   description = "This variable has been placed above the module declaration to facilitate easy changes between projects. The first index should always be the main cluster"
 
@@ -94,6 +103,7 @@ module "k8s" {
   k8s_options               = var.default_k8s_options
   node_options              = var.default_node_options
   node_metadata             = var.default_node_metadata
+  node_tags                 = ["${var.cluster_config["0"]}-${var.cluster_region}"]  
   client_certificate_config = var.default_client_certificate_config
   cloud_nat_address_name    = "${var.cluster_config["0"]}-${var.cluster_region}-nat"
   create_namespace          = var.default_create_namespace
@@ -113,6 +123,7 @@ module "k8s-sandbox" {
   k8s_options               = var.default_k8s_options
   node_options              = var.default_node_options
   node_metadata             = var.default_node_metadata
+  node_tags                 = ["${var.cluster_config["1"]}-${var.cluster_region}"]
   client_certificate_config = var.default_client_certificate_config
   cloud_nat_address_name    = "${var.cluster_config["1"]}-${var.cluster_region}-nat"
   create_namespace          = var.default_create_namespace
@@ -181,6 +192,108 @@ module "k8s-spinnaker-service-account-sandbox" {
 
   providers = {
     kubernetes = kubernetes.sandbox
+  }
+}
+
+module "k8s-spinnaker-agent" {
+  source          = "github.com/devorbitus/terraform-google-gke-infra"
+  name            = "${var.agent_cluster_config["0"]}-${var.cluster_region}"
+  project         = var.gcp_project
+  region          = var.cluster_region
+  private_cluster = true # This will disable public IPs from the nodes
+
+  networks_that_can_access_k8s_api = compact(flatten([var.default_networks_that_can_access_k8s_api, [formatlist("%s/32", [trimspace(data.http.local_outgoing_ip_address.body)])], [formatlist("%s/32", data.google_compute_address.halyard_ip_address.address)]]))
+
+  oauth_scopes              = var.default_oauth_scopes
+  k8s_options               = var.default_k8s_options
+  node_metadata             = var.default_node_metadata
+  node_options              = var.second_clsuter_node_options
+  node_pool_options         = var.second_clsuter_node_pool_options
+  client_certificate_config = var.default_client_certificate_config
+  cloud_nat                 = false                                                 # Will re-use the cloud nat created by the primary cluster
+  node_tags                 = ["${var.cluster_config["0"]}-${var.cluster_region}"]  # Use the same network tags as primary cluster
+  create_namespace          = var.default_create_namespace
+  extras                    = var.extras
+}
+
+provider "kubernetes" {
+  load_config_file       = false
+  host                   = module.k8s-spinnaker-agent.endpoint
+  cluster_ca_certificate = base64decode(module.k8s-spinnaker-agent.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+  alias                  = "spinnaker-agent"
+}
+
+module "k8s-spinnaker-service-account-spinnaker-agent" {
+  source                    = "./modules/k8s-service-account"
+  service_account_name      = "spinnaker"
+  service_account_namespace = "kube-system"
+  bucket_name               = module.halyard-storage.bucket_name
+  gcp_project               = var.gcp_project
+  cluster_name              = var.agent_cluster_config["0"]
+  cluster_config            = var.cluster_config
+  cluster_region            = var.cluster_region
+  host                      = module.k8s-spinnaker-agent.endpoint
+  cluster_ca_certificate    = module.k8s-spinnaker-agent.cluster_ca_certificate
+  enable                    = true
+  cluster_list_index        = 1
+  cloudsql_credentials      = module.spinnaker-gcp-cloudsql-service-account.service-account-json
+  spinnaker_namespace       = length(module.k8s-spinnaker-agent.created_namespace) > 0 ? module.k8s-spinnaker-agent.created_namespace.0.metadata.0.name : var.default_create_namespace
+  spinnaker_nodepool        = module.k8s-spinnaker-agent.created_nodepool
+
+  providers = {
+    kubernetes = kubernetes.spinnaker-agent
+  }
+}
+
+module "k8s-sandbox-agent" {
+  source          = "github.com/devorbitus/terraform-google-gke-infra"
+  name            = "${var.agent_cluster_config["1"]}-${var.cluster_region}"
+  project         = var.gcp_project
+  region          = var.cluster_region
+  private_cluster = true # This will disable public IPs from the nodes
+
+  networks_that_can_access_k8s_api = compact(flatten([var.default_networks_that_can_access_k8s_api, [formatlist("%s/32", [trimspace(data.http.local_outgoing_ip_address.body)])], [formatlist("%s/32", data.google_compute_address.halyard_ip_address.address)]]))
+
+  oauth_scopes              = var.default_oauth_scopes
+  k8s_options               = var.default_k8s_options
+  node_metadata             = var.default_node_metadata
+  node_options              = var.second_clsuter_node_options
+  node_pool_options         = var.second_clsuter_node_pool_options
+  client_certificate_config = var.default_client_certificate_config
+  cloud_nat                 = false                                                 # Will re-use the cloud nat created by the primary cluster
+  node_tags                 = ["${var.cluster_config["1"]}-${var.cluster_region}"]  # Use the same network tags as primary cluster
+  create_namespace          = var.default_create_namespace
+  extras                    = var.extras
+}
+
+provider "kubernetes" {
+  load_config_file       = false
+  host                   = module.k8s-sandbox-agent.endpoint
+  cluster_ca_certificate = base64decode(module.k8s-sandbox-agent.cluster_ca_certificate)
+  token                  = data.google_client_config.current.access_token
+  alias                  = "sandbox-agent"
+}
+
+module "k8s-spinnaker-service-account-sandbox-agent" {
+  source                    = "./modules/k8s-service-account"
+  service_account_name      = "spinnaker"
+  service_account_namespace = "kube-system"
+  bucket_name               = module.halyard-storage.bucket_name
+  gcp_project               = var.gcp_project
+  cluster_name              = var.agent_cluster_config["1"]
+  cluster_config            = var.cluster_config
+  cluster_region            = var.cluster_region
+  host                      = module.k8s-sandbox-agent.endpoint
+  cluster_ca_certificate    = module.k8s-sandbox-agent.cluster_ca_certificate
+  enable                    = true
+  cluster_list_index        = 1
+  cloudsql_credentials      = module.spinnaker-gcp-cloudsql-service-account.service-account-json
+  spinnaker_namespace       = length(module.k8s-sandbox-agent.created_namespace) > 0 ? module.k8s-sandbox-agent.created_namespace.0.metadata.0.name : var.default_create_namespace
+  spinnaker_nodepool        = module.k8s-sandbox-agent.created_nodepool
+
+  providers = {
+    kubernetes = kubernetes.sandbox-agent
   }
 }
 

--- a/spinnaker/modules/crypto_key/vars.tf
+++ b/spinnaker/modules/crypto_key/vars.tf
@@ -9,7 +9,7 @@ variable "cluster_region" {
 
 variable "kms_key_ring_self_link" {
   type        = string
-  description = "The self link of the created KeyRing in the format projects/[project}/locations/{location}/keyRings/{name}"
+  description = "The self link of the created KeyRing in the format projects/{project}/locations/{location}/keyRings/{name}"
 }
 
 variable "cluster_key_map" {

--- a/spinnaker/vars.tf
+++ b/spinnaker/vars.tf
@@ -39,7 +39,7 @@ variable "default_node_options" {
   }
 }
 
-variable "second_clsuter_node_options" {
+variable "second_cluster_node_options" {
   description = "These are the default options node options for the second cluster node pool"
   type        = map(string)
 
@@ -52,7 +52,7 @@ variable "second_clsuter_node_options" {
   }
 }
 
-variable "second_clsuter_node_pool_options" {
+variable "second_cluster_node_pool_options" {
   type        = map(string)
   description = "Options to configure the default Node Pool created for the second cluster."
 

--- a/spinnaker/vars.tf
+++ b/spinnaker/vars.tf
@@ -39,6 +39,32 @@ variable "default_node_options" {
   }
 }
 
+variable "second_clsuter_node_options" {
+  description = "These are the default options node options for the second cluster node pool"
+  type        = map(string)
+
+  default = {
+    disk_size    = 20
+    disk_type    = "pd-standard"
+    image        = "COS"
+    machine_type = "n1-standard-1"
+    preemptible  = true
+  }
+}
+
+variable "second_clsuter_node_pool_options" {
+  type        = map(string)
+  description = "Options to configure the default Node Pool created for the second cluster."
+
+  default = {
+    auto_repair           = true # Whether the nodes will be automatically repaired.
+    auto_upgrade          = true # Whether the nodes will be automatically upgraded.
+    autoscaling_nodes_min = 1    # Minimum number of nodes to create in each zone. Must be >=1 and <= autoscaling_nodes_max.
+    autoscaling_nodes_max = 10   # Maximum number of nodes to create in each zone. Must be >= autoscaling_nodes_min.
+    max_pods_per_node     = 110  # The maximum number of pods per node in this node pool. Note this setting is currently in Beta: https://www.terraform.io/docs/providers/google/r/container_node_pool.html#max_pods_per_node
+  }
+}
+
 variable "default_k8s_options" {
   description = "These are the default options for the cluster"
   type        = map(string)

--- a/spinnaker/vars.tf
+++ b/spinnaker/vars.tf
@@ -48,7 +48,7 @@ variable "second_cluster_node_options" {
     disk_type    = "pd-standard"
     image        = "COS"
     machine_type = "n1-standard-1"
-    preemptible  = true
+    preemptible  = false
   }
 }
 


### PR DESCRIPTION
This creates a second GKE cluster for running 'agent' jobs

This expects that the agent cluster will be onboarded through your normal process and will __not__
- Create a kubernetes provider account for the second cluster
- Add the Cloud NAT IP address to the master auth networks list