### PR TITLE
Spinnaker onboarding account

### DIFF
--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -112,7 +112,7 @@ CLOUDDRIVER_PATCH
 yq write -i -s /tmp/halconfig-clouddriver-patch-${DEPLOYMENT_INDEX}.yml /${USER}/.hal/config && rm /tmp/halconfig-clouddriver-patch-${DEPLOYMENT_INDEX}.yml
 
 
-tee <<EOF > /${USER}/.kube/kubeconfig_patch.yml
+tee /${USER}/.kube/kubeconfig_patch.yml <<EOF
 users.0.user.exec.apiVersion: client.authentication.k8s.io/v1beta1
 users.0.user.exec.args[+]: "/tmp/gcloud/auth_token"
 users.0.user.exec.command: /bin/cat

--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -263,7 +263,7 @@ redis:
 FRONT50_LOCAL
 
 # Changing health check to be native instead of wget https://github.com/spinnaker/spinnaker/issues/4479
-cat <<EOF >> /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/gate.yml
+tee /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/gate.yml << EOF
 kubernetes:
   useExecHealthCheck: false
 

--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -112,7 +112,7 @@ CLOUDDRIVER_PATCH
 yq write -i -s /tmp/halconfig-clouddriver-patch-${DEPLOYMENT_INDEX}.yml /${USER}/.hal/config && rm /tmp/halconfig-clouddriver-patch-${DEPLOYMENT_INDEX}.yml
 
 
-tee /${USER}/.kube/kubeconfig_patch.yml <<EOF
+tee /${USER}/.kube/kubeconfig_patch.yml << EOF
 users.0.user.exec.apiVersion: client.authentication.k8s.io/v1beta1
 users.0.user.exec.args[+]: "/tmp/gcloud/auth_token"
 users.0.user.exec.command: /bin/cat

--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -118,7 +118,7 @@ users.0.user.exec.args[+]: "/tmp/gcloud/auth_token"
 users.0.user.exec.command: /bin/cat
 EOF
 
-cat <<EOF > /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/clouddriver.yml
+tee /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/clouddriver.yml << EOF
 kubernetes:
   serviceAccountName: spinnaker-onboarding
 
@@ -290,7 +290,7 @@ if [[ -f /${USER}/vault/dyn_acct_${DEPLOYMENT_NAME}_rw_token && -s /${USER}/vaul
     
     echo "Configuring Spinnaker dynamic account for deployment ${DEPLOYMENT_NAME}"
 
-    cat <<DYN_CONFIG >> /${USER}/.hal/${DEPLOYMENT_NAME}/profiles/spinnakerconfig.yml
+    tee /${USER}/.hal/${DEPLOYMENT_NAME}/profiles/spinnakerconfig.yml << DYN_CONFIG
 spring:
   profiles:
     include: vault
@@ -312,7 +312,7 @@ DYN_CONFIG
 else
     echo "Dynamic Account Tokens NOT found so skipping configuring dynamic account for deployment ${DEPLOYMENT_NAME}"
 fi
-cat <<SETTINGS_LOCAL >> /${USER}/.hal/${DEPLOYMENT_NAME}/profiles/settings-local.js
+tee /${USER}/.hal/${DEPLOYMENT_NAME}/profiles/settings-local.js << SETTINGS_LOCAL
 window.spinnakerSettings.notifications.email.enabled = false;
 window.spinnakerSettings.notifications.bearychat.enabled = false;
 SETTINGS_LOCAL

--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -111,13 +111,14 @@ CLOUDDRIVER_PATCH
 
 yq write -i -s /tmp/halconfig-clouddriver-patch-${DEPLOYMENT_INDEX}.yml /${USER}/.hal/config && rm /tmp/halconfig-clouddriver-patch-${DEPLOYMENT_INDEX}.yml
 
-cat <<EOF >> /${USER}/.kube/kubeconfig_patch.yml
+
+tee <<EOF > /${USER}/.kube/kubeconfig_patch.yml
 users.0.user.exec.apiVersion: client.authentication.k8s.io/v1beta1
 users.0.user.exec.args[+]: "/tmp/gcloud/auth_token"
 users.0.user.exec.command: /bin/cat
 EOF
 
-cat <<EOF >> /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/clouddriver.yml
+cat <<EOF > /${USER}/.hal/${DEPLOYMENT_NAME}/service-settings/clouddriver.yml
 kubernetes:
   serviceAccountName: spinnaker-onboarding
 

--- a/halyard/halScripts/setupHalyard.sh
+++ b/halyard/halScripts/setupHalyard.sh
@@ -281,7 +281,7 @@ if [[ -f /${USER}/vault/dyn_acct_${DEPLOYMENT_NAME}_rw_token && -s /${USER}/vaul
     # and store that into the vault secret
     yq r -j \
         /${USER}/.hal/config deploymentConfigurations.${DEPLOYMENT_INDEX}.providers.kubernetes.accounts.0 | \
-        jq --arg contents "$(yq r $(yq r .hal/config deploymentConfigurations.${DEPLOYMENT_INDEX}.providers.kubernetes.accounts.0.kubeconfigFile) | \
+        jq --arg contents "$(yq r $(yq r /${USER}/.hal/config deploymentConfigurations.${DEPLOYMENT_INDEX}.providers.kubernetes.accounts.0.kubeconfigFile) | \
          yq d - users.0.user.token | yq w - -s /${USER}/.kube/kubeconfig_patch.yml | sed -E ':a;N;$!ba;s/\r{0,1}\n/\n/g')" \
         'del(.kubeconfigFile) | . += {"kubeconfigContents":$contents} | {"kubernetes":{"accounts":[.]}}' | \
         vault kv put \

--- a/halyard/halScripts/setup_kubernetes_dynamic.sh
+++ b/halyard/halScripts/setup_kubernetes_dynamic.sh
@@ -142,6 +142,12 @@ else
     echo "Creating Spinnaker namespace and cloudsql-instance-credentials secret"
     kubectl --kubeconfig="$CONFIG_FILE" create ns spinnaker
     kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker create secret generic cloudsql-instance-credentials --from-file=/${USER}/.gcp/secret
+    kubectl --kubeconfig="$CONFIG_FILE" create serviceaccount -n spinnaker spinnaker-onboarding
+    kubectl --kubeconfig="$CONFIG_FILE" annotate serviceaccount -n spinnaker spinnaker-onboarding \
+        iam.gke.io/gcp-service-account=${ONBOARDING_SA_EMAIL}
+    kubectl --kubeconfig="$CONFIG_FILE" create serviceaccount -n spinnaker ${deployment}
+    kubectl --kubeconfig="$CONFIG_FILE" annotate serviceaccount -n spinnaker ${deployment} \
+        iam.gke.io/gcp-service-account=${deployment}@${PROJECT}.iam.gserviceaccount.com
 fi
 
 %{ endfor ~}

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -338,9 +338,10 @@ data "template_file" "setupKubernetesMultiple" {
   vars = {
     SHEBANG = "#!/bin/bash"
     SCRIPT_CONTENT = templatefile("./halScripts/setup_kubernetes_dynamic.sh", {
-      PROJECT     = var.gcp_project
-      USER        = var.service_account_name
-      deployments = zipmap(concat(keys(data.terraform_remote_state.static_ips.outputs.ship_plans), formatlist("%s-agent", keys(data.terraform_remote_state.static_ips.outputs.ship_plans))), concat(values(data.terraform_remote_state.static_ips.outputs.ship_plans), values(data.terraform_remote_state.static_ips.outputs.ship_plans)))
+      PROJECT             = var.gcp_project
+      USER                = var.service_account_name
+      ONBOARDING_SA_EMAIL = data.terraform_remote_state.spinnaker.outputs.spinnaker_onboarding_service_account_email
+      deployments         = zipmap(concat(keys(data.terraform_remote_state.static_ips.outputs.ship_plans), formatlist("%s-agent", keys(data.terraform_remote_state.static_ips.outputs.ship_plans))), concat(values(data.terraform_remote_state.static_ips.outputs.ship_plans), values(data.terraform_remote_state.static_ips.outputs.ship_plans)))
     })
   }
 }

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -186,6 +186,16 @@ module "onboarding_pubsub_service_account" {
   roles                  = ["roles/storage.admin", "roles/pubsub.subscriber"]
 }
 
+module "spinnaker_onboarding_service_account" {
+  source                 = "./modules/gcp-service-account"
+  service_account_name   = "spinnaker-onboarding"
+  service_account_prefix = ""
+  bucket_name            = module.halyard_storage.bucket_name
+  gcp_project            = var.gcp_project
+  roles                  = []
+  create_and_store_key   = false
+}
+
 module "halyard_service_account" {
   source               = "./modules/gcp-service-account"
   service_account_name = "spinnaker-halyard"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -192,8 +192,28 @@ module "spinnaker_onboarding_service_account" {
   service_account_prefix = ""
   bucket_name            = module.halyard_storage.bucket_name
   gcp_project            = var.gcp_project
-  roles                  = []
+  roles                  = ["roles/container.admin"]
   create_and_store_key   = false
+}
+
+resource "google_service_account_iam_binding" "onboarding_workload_identity_binding" {
+  service_account_id = module.spinnaker_onboarding_service_account.service_account_name
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${var.gcp_project}.svc.id.goog[spinnaker/spinnaker-onboarding]",
+  ]
+}
+
+resource "google_service_account_iam_binding" "k8s_sa_workload_identity_binding" {
+  for_each = data.terraform_remote_state.static_ips.outputs.ship_plans
+  service_account_id = module.k8s.service_account_name_map[each.key]
+  role               = "roles/iam.workloadIdentityUser"
+
+  members = [
+    "serviceAccount:${var.gcp_project}.svc.id.goog[spinnaker/${each.key}]",
+    "serviceAccount:${var.gcp_project}.svc.id.goog[vault/vault]",
+  ]
 }
 
 module "halyard_service_account" {
@@ -248,6 +268,10 @@ module "vault_setup" {
   vault_ips_map        = data.terraform_remote_state.static_ips.outputs.vault_ips_map
   crypto_key_id_map    = module.vault_keys.crypto_key_id_map
   ship_plans           = data.terraform_remote_state.static_ips.outputs.ship_plans
+}
+
+output "spinnaker_onboarding_service_account_email" {
+  value = module.spinnaker_onboarding_service_account.service_account_email
 }
 
 output "vault_keyring_name_map" {

--- a/spinnaker/modules/gcp-service-account/gcp-service-account.tf
+++ b/spinnaker/modules/gcp-service-account/gcp-service-account.tf
@@ -17,13 +17,13 @@ resource "google_service_account_key" "svc_key" {
 resource "vault_generic_secret" "service_account_key" {
   for_each  = var.create_and_store_key ? { enabled = true } : {}
   path      = "secret/${var.gcp_project}/${var.service_account_name}"
-  data_json = base64decode(google_service_account_key.svc_key.private_key)
+  data_json = base64decode(google_service_account_key.svc_key["enabled"].private_key)
 }
 
 resource "google_storage_bucket_object" "service_account_key_storage" {
   for_each     = var.create_and_store_key ? { enabled = true } : {}
   name         = ".gcp/${var.service_account_name}.json"
-  content      = base64decode(google_service_account_key.svc_key.private_key)
+  content      = base64decode(google_service_account_key.svc_key["enabled"].private_key)
   bucket       = var.bucket_name
   content_type = "application/json"
 }

--- a/spinnaker/modules/gcp-service-account/vars.tf
+++ b/spinnaker/modules/gcp-service-account/vars.tf
@@ -19,3 +19,8 @@ variable "gcp_project" {
 variable "roles" {
   type = list(string)
 }
+
+variable "create_and_store_key" {
+  type    = bool
+  default = true
+}

--- a/spinnaker/modules/k8s/outputs.tf
+++ b/spinnaker/modules/k8s/outputs.tf
@@ -49,6 +49,10 @@ output "service_account_key_map" {
   value = var.service_account == "" ? { for k, v in var.ship_plans_without_agent : k => google_service_account_key.sa_key[k].private_key } : { for k, v in var.ship_plans : k => "" }
 }
 
+output "service_account_name_map" {
+  value = var.service_account == "" ? { for k, v in var.ship_plans_without_agent : k => google_service_account.sa[k].name } : { for k, v in var.ship_plans : k => var.service_account }
+}
+
 output "cloud_nat_adddress_map" {
   value = { for k, v in var.ship_plans : k => data.google_compute_address.existing_nat[k].address }
 }

--- a/spinnaker/modules/vault/vault.tf
+++ b/spinnaker/modules/vault/vault.tf
@@ -45,6 +45,7 @@ data "template_file" "vault" {
     kms_crypto_key   = "vault_key_${each.key}"
     crypto_key_id    = lookup(var.crypto_key_id_map, each.key, "")
     project          = var.gcp_project
+    cluster_sa_email = "${each.key}@${var.gcp_project}.iam.gserviceaccount.com"
     cluster_region   = each.value["clusterRegion"]
     load_balancer_ip = lookup(var.vault_ips_map, each.key, "")
   }

--- a/spinnaker/modules/vault/vault.yml
+++ b/spinnaker/modules/vault/vault.yml
@@ -39,6 +39,10 @@ server:
       - name: VAULT_SECRET_THRESHOLD
         value: "3"
 
+  serviceAccount:
+    annotations: |
+      "iam.gke.io/gcp-service-account": "${cluster_sa_email}"
+
   extraVolumes:
     - type: secret
       name: vault-tls

--- a/spinnaker/modules/vault/vault.yml
+++ b/spinnaker/modules/vault/vault.yml
@@ -40,7 +40,7 @@ server:
         value: "3"
 
   serviceAccount:
-    annotations: |
+    annotations:
       "iam.gke.io/gcp-service-account": "${cluster_sa_email}"
 
   extraVolumes:

--- a/spinnaker/vars.tf
+++ b/spinnaker/vars.tf
@@ -156,10 +156,10 @@ variable "extras" {
   description = "Extra options to configure K8s. These are options that are unlikely to change from deployment to deployment. All options must be specified when passed as a map variable input to this module."
 
   default = {
-    kubernetes_alpha       = false    # Enable Kubernetes Alpha features for this cluster. When this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days.
-    local_ssd_count        = 0        # The amount of local SSD disks that will be attached to each cluster node.
-    maintenance_start_time = "01:00"  # Time window specified for daily maintenance operations. Specify start_time in RFC3339 format "HH:MM”, where HH : [00-23] and MM : [00-59] GMT.
-    metadata_config        = "EXPOSE" # How to expose the node metadata to the workload running on the node. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_metadata
+    kubernetes_alpha       = false                 # Enable Kubernetes Alpha features for this cluster. When this option is enabled, the cluster cannot be upgraded and will be automatically deleted after 30 days.
+    local_ssd_count        = 0                     # The amount of local SSD disks that will be attached to each cluster node.
+    maintenance_start_time = "01:00"               # Time window specified for daily maintenance operations. Specify start_time in RFC3339 format "HH:MM”, where HH : [00-23] and MM : [00-59] GMT.
+    metadata_config        = "GKE_METADATA_SERVER" # How to expose the node metadata to the workload running on the node. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#node_metadata
   }
   # guest_accelerator  = ""       # The accelerator type resource to expose to this instance. E.g. nvidia-tesla-k80. If unset will not attach an accelerator.
   # min_cpu_platform = "" # Minimum CPU platform to be used by this instance. The instance may be scheduled on the specified or newer CPU platform. Applicable values are the friendly names of CPU platforms, such as Intel Haswell.


### PR DESCRIPTION
This PR creates the `spinnaker-onboarding` google service account as well as automatically setting up Google Kubernetes Engine Workload Identity. It creates all the kubernetes accounts and wires them all up including roles and configures Clouddriver to use Workload Identity for Dynamic Accounts for both Spinnaker itself as well as future automated customer onboarding.