### PR TITLE
More multi dns fixes

### DIFF
--- a/beforepush.sh
+++ b/beforepush.sh
@@ -5,4 +5,7 @@ if ! command -v docker; then
 fi
 
 GIT_ROOT=$(git rev-parse --show-toplevel)
-docker run -v "$GIT_ROOT:/mnt" npmaile/spingo-sanity-tests bash -c /mnt/scripts/pre-push-tests.sh
+docker run \
+    -v "$GIT_ROOT:/mnt:ro" \
+    npmaile/spingo-sanity-tests bash \
+    -c /mnt/scripts/pre-push-tests.sh

--- a/halyard/halScripts/make_or_update_keystore.sh
+++ b/halyard/halScripts/make_or_update_keystore.sh
@@ -20,7 +20,7 @@ do
    docker run \
   -e GCE_PROJECT="${PROJECT}" \
   -e GCE_SERVICE_ACCOUNT_FILE="/gcloud-service-account.json" \
-  -v /${USER}/.gcp/certbot.json:/gcloud-service-account.json:ro \
+  -v ${DNS_SA_KEY_PATH}:/gcloud-service-account.json:ro \
   -v /${USER}/certstore:/certstore \
   -u 1978:1978 \
     goacme/lego \

--- a/halyard/halScripts/setupSSL.sh
+++ b/halyard/halScripts/setupSSL.sh
@@ -19,8 +19,15 @@ hal config security ui ssl edit \
     --deployment ${DEPLOYMENT_NAME}
 
 # using expect to automate the required interactive password prompt
+echo "=============================================================="
+echo "   ********   AUTOMATION WILL INPUT   ******** "
+echo "   ********   NO USER INPUT REQUIRED  ******** "
+echo "=============================================================="
 expect -c "spawn hal config security ui ssl edit --deployment ${DEPLOYMENT_NAME} --ssl-certificate-passphrase; sleep 1; expect -exact \"The passphrase needed to unlock your SSL certificate. This will be provided to Apache on startup.: \"; send -- \"${KEYSTORE_PASS}\r\"; expect eof"
-
+echo "=============================================================="
+echo "   ********   AUTOMATION WILL INPUT   ******** "
+echo "   ********   NO USER INPUT REQUIRED  ******** "
+echo "=============================================================="
 expect -c "spawn hal config security api ssl edit --deployment ${DEPLOYMENT_NAME} --key-alias spinnaker --keystore /${USER}/certbot/$WILDCARD_KEYSTORE --keystore-password --keystore-type jks --truststore /${USER}/certbot/$WILDCARD_KEYSTORE --truststore-password --truststore-type jks; sleep 1; expect -exact \"The password to unlock your keystore. Due to a limitation in Tomcat, this must match your key's password in the keystore.: \"; send -- \"${KEYSTORE_PASS}\r\"; expect -exact \"\rThe password to unlock your truststore.: \"; send -- \"${KEYSTORE_PASS}\r\"; expect eof"
 
 hal config security api ssl enable \

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -445,14 +445,8 @@ data "vault_generic_secret" "slack_token" {
   path = "secret/${var.gcp_project}/slack-token"
 }
 
-#This is manually put into vault and created manually
-#Get OAUTH secrets
 data "vault_generic_secret" "gcp_oauth" {
   path = "secret/${var.gcp_project}/gcp-oauth"
-}
-
-data "google_compute_network" "network" {
-  name = var.network_name
 }
 
 resource "google_compute_instance" "halyard_spin_vm" {
@@ -474,8 +468,8 @@ resource "google_compute_instance" "halyard_spin_vm" {
   }
 
   network_interface {
-    network    = data.google_compute_network.network.name
-    subnetwork = var.subnet_name != "" ? var.subnet_name : data.google_compute_network.network.subnetworks_self_links[0]
+    network    = data.terraform_remote_state.spinnaker.outputs.halyard_network_name
+    subnetwork = data.terraform_remote_state.spinnaker.outputs.halyard_subnetwork_name
 
     access_config {
       nat_ip = data.terraform_remote_state.static_ips.outputs.halyard_ip
@@ -491,5 +485,5 @@ resource "google_compute_instance" "halyard_spin_vm" {
 }
 
 output "halyard_command" {
-  value = "gcloud beta compute --project \"${var.gcp_project}\" ssh --zone \"${var.gcp_zone}\" \"${google_compute_instance.halyard_spin_vm.name}\""
+  value = "gcloud beta compute --project \"${var.gcp_project}\" ssh --tunnel-through-iap --zone \"${var.gcp_zone}\" \"${google_compute_instance.halyard_spin_vm.name}\""
 }

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -458,6 +458,10 @@ resource "google_compute_instance" "halyard_spin_vm" {
     automatic_restart = true
   }
 
+  tags = [
+    data.terraform_remote_state.spinnaker.outputs.halyard_network_name
+  ]
+
   boot_disk {
     initialize_params {
       image = "ubuntu-os-cloud/ubuntu-1604-lts"

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -79,7 +79,7 @@ data "template_file" "vault" {
 resource "google_storage_bucket_object" "dns_certbot_service_account_key_storage" {
   for_each     = var.gcp_project != var.dns_gcp_project ? { enabled = true } : {}
   name         = ".gcp/certbot-dns.json"
-  content      = data.vault_generic_secret.certbot_dns_key["enabled"].data_json
+  content      = data.vault_generic_secret.certbot_dns_key["enabled"].data[var.dns_gcp_project]
   bucket       = "${var.gcp_project}${var.bucket_name}"
   content_type = "application/json"
 }
@@ -456,7 +456,7 @@ data "vault_generic_secret" "slack_token" {
 
 data "vault_generic_secret" "certbot_dns_key" {
   for_each = var.gcp_project != var.dns_gcp_project ? { enabled = true } : {}
-  path     = "secret/${var.dns_gcp_project}/certbot"
+  path     = "secret/${var.dns_gcp_project}/terraform-account"
 }
 
 data "vault_generic_secret" "gcp_oauth" {

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -76,15 +76,24 @@ data "template_file" "vault" {
   }
 }
 
+resource "google_storage_bucket_object" "dns_certbot_service_account_key_storage" {
+  for_each     = var.gcp_project != var.dns_gcp_project ? { enabled = true } : {}
+  name         = ".gcp/certbot-dns.json"
+  content      = data.vault_generic_secret.certbot_dns_key["enabled"].data_json
+  bucket       = "${var.gcp_project}${var.bucket_name}"
+  content_type = "application/json"
+}
+
 data "template_file" "make_update_keystore_script" {
   template = file("./halScripts/make_or_update_keystore.sh")
 
   vars = {
-    DNS           = var.cloud_dns_hostname
-    KEYSTORE_PASS = data.vault_generic_secret.keystore_pass.data["value"]
-    PROJECT       = var.gcp_project
-    USER          = var.service_account_name
-    CERTBOT_EMAIL = var.certbot_email
+    DNS             = var.cloud_dns_hostname
+    KEYSTORE_PASS   = data.vault_generic_secret.keystore_pass.data["value"]
+    PROJECT         = var.gcp_project != var.dns_gcp_project ? var.dns_gcp_project : var.gcp_project
+    DNS_SA_KEY_PATH = var.gcp_project != var.dns_gcp_project ? "/${var.service_account_name}/.gcp/certbot-dns.json" : "/${var.service_account_name}/.gcp/certbot.json"
+    USER            = var.service_account_name
+    CERTBOT_EMAIL   = var.certbot_email
   }
 }
 
@@ -443,6 +452,11 @@ data "vault_generic_secret" "front50_db_migrate_user_password" {
 
 data "vault_generic_secret" "slack_token" {
   path = "secret/${var.gcp_project}/slack-token"
+}
+
+data "vault_generic_secret" "certbot_dns_key" {
+  for_each = var.gcp_project != var.dns_gcp_project ? { enabled = true } : {}
+  path     = "secret/${var.dns_gcp_project}/certbot"
 }
 
 data "vault_generic_secret" "gcp_oauth" {

--- a/halyard/start.sh
+++ b/halyard/start.sh
@@ -44,6 +44,7 @@ echo "Installing Vault"
 runuser -l ${USER} -c 'curl "https://releases.hashicorp.com/vault/1.2.3/vault_1.2.3_linux_amd64.zip" > /home/${USER}/vault.zip'
 runuser -l ${USER} -c 'unzip /home/${USER}/vault.zip -d /home/${USER}'
 runuser -l ${USER} -c 'sudo mv /home/${USER}/vault /usr/local/bin/vault'
+runuser -l ${USER} -c 'rm /home/${USER}/vault.zip'
 
 echo "Installing Helm"
 runuser -l ${USER} -c 'curl -LO https://git.io/get_helm.sh'

--- a/halyard/vars.tf
+++ b/halyard/vars.tf
@@ -64,13 +64,3 @@ variable "use_local_credential_file" {
   type    = bool
   default = false
 }
-
-variable "network_name" {
-  type    = string
-  default = "default"
-}
-
-variable "subnet_name" {
-  type    = string
-  default = ""
-}

--- a/halyard/vars.tf
+++ b/halyard/vars.tf
@@ -3,8 +3,8 @@ variable "gcp_project" {
   type        = string
 }
 
-variable "dns_gcp_project" {
-  description = "DNS GCP project name"
+variable "managed_dns_gcp_project" {
+  description = "GCP project name where the DNS managed zone lives"
   type        = string
 }
 

--- a/halyard/vars.tf
+++ b/halyard/vars.tf
@@ -1,5 +1,11 @@
 variable "gcp_project" {
   description = "GCP project name"
+  type        = string
+}
+
+variable "dns_gcp_project" {
+  description = "DNS GCP project name"
+  type        = string
 }
 
 variable "gcp_zone" {

--- a/quickstart.sh
+++ b/quickstart.sh
@@ -31,8 +31,8 @@ setup_and_run_tf(){
 
     if [ "$RUN_DNS_IMPORT" == "true" ]; then
         echo "Existing Cloud DNS setup found so attempting to import"
-        DNS_PROJECT=$(cat "$GIT_ROOT_DIR/dns/var-gcp_project.auto.tfvars" | cut -d "\"" -f 2 -)
-        DNS_HOSTNAME=$(cat "$GIT_ROOT_DIR/dns/var-cloud_dns_hostname.auto.tfvars" | cut -d "\"" -f 2 -)
+        DNS_PROJECT=$(cut -d "\"" -f 2 "$GIT_ROOT_DIR/dns/var-gcp_project.auto.tfvars")
+        DNS_HOSTNAME=$(cut -d "\"" -f 2 "$GIT_ROOT_DIR/dns/var-cloud_dns_hostname.auto.tfvars")
         
         if terraform state list | grep "google_dns_managed_zone.project_zone"; then
             echo "Already imported Cloud DNS managed zone so nothing to import"

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -178,6 +178,102 @@ check_for_hostname_used() {
     fi
 }
 
+create_service_account(){
+    # $1 = Service account name to create
+    SA_NAME="$1"
+    echoerr "creating $SA_NAME service account"
+    SA_EMAIL="$(gcloud iam service-accounts list \
+        --filter="displayName:${SA_NAME}" \
+        --format='value(email)')"
+    if [ -n "$SA_EMAIL" ]; then
+        echoerr "Service account $SA_NAME already exists so no need to create it"
+    else
+        gcloud iam service-accounts create \
+            "$SA_NAME" \
+            --display-name "$SA_NAME"
+    fi
+
+    while [ -z "$SA_EMAIL" ]; do
+        echoerr "waiting for service account to be fully created..."
+        sleep 1
+        SA_EMAIL="$(gcloud iam service-accounts list \
+            --filter="displayName:${SA_NAME}" \
+            --format='value(email)')"
+    done
+
+    echoerr "Service account $SA_NAME created"
+}
+
+add_roles_to_service_account(){
+    # $1 = Service account name to add roles to
+    # $2 = list of roles to add if they don't already exist
+    # $3 = Project ID
+    SERVICE_ACCOUNT_NAME="$1"
+    list="$2[@]"
+    PROJECT="$3"
+    roles=("${!list}")
+
+    SA_EMAIL="$(gcloud iam service-accounts list \
+        --filter="displayName:${SERVICE_ACCOUNT_NAME}" \
+        --format='value(email)')"
+
+    if [ -n "$SA_EMAIL" ]; then
+        echoerr "adding roles to $SERVICE_ACCOUNT_NAME for $SA_EMAIL"
+
+        EXISTING_ROLES="$(gcloud projects get-iam-policy "$PROJECT" --flatten="bindings[].members" --format="json" --filter="bindings.members:$SA_EMAIL" | jq -r '.[].bindings' | jq -s '.')"
+
+        for role in "${roles[@]}"; do
+            EXISTING_ROLE_CHECK="$(echo "$EXISTING_ROLES" | jq -r --arg rl "$role" '.[] | select(.role == $rl) | .role')"
+            if [ -z "$EXISTING_ROLE_CHECK" ]; then
+                echoerr "Attempting to add role $role to service account $SERVICE_ACCOUNT_NAME"
+                
+                if gcloud --no-user-output-enabled projects add-iam-policy-binding "$PROJECT" \
+                    --member serviceAccount:"$SA_EMAIL" \
+                    --role="$role"; then
+                    echoerr "Added role $role to service account $SERVICE_ACCOUNT_NAME"
+                else
+                    echoerr "Unable to add role $role to service account $SERVICE_ACCOUNT_NAME"
+                fi
+            else
+                echoerr "Role $role already exists on service account $SERVICE_ACCOUNT_NAME so nothing to add"
+            fi
+        done
+    else
+        echoerr "Unable to add roles to service account $SERVICE_ACCOUNT_NAME because it doesn't appear to exist"
+        exit 1
+    fi
+}
+
+create_and_save_service_account_key(){
+    # $1 = Service account name to add roles to
+    # $2 = list of roles to add if they don't already exist
+    # $3 = Path to store the newly created service account key
+    SERVICE_ACCOUNT_NAME="$1"
+    SERVICE_ACCOUNT_DEST="$2"
+    PROJECT="$3"
+
+    SA_EMAIL="$(gcloud iam service-accounts list \
+        --filter="displayName:${SERVICE_ACCOUNT_NAME}" \
+        --format='value(email)')"
+
+    if [ -n "$SA_EMAIL" ]; then
+        EXISTING_KEY="$(vault read -field="$PROJECT" "secret/$PROJECT/$SERVICE_ACCOUNT_NAME")"
+        if [ -z "$EXISTING_KEY" ]; then
+            echoerr "generating keys for $SERVICE_ACCOUNT_NAME"
+            gcloud iam service-accounts keys create "$SERVICE_ACCOUNT_DEST" \
+                --iam-account "$SA_EMAIL"
+            echoerr "writing $SERVICE_ACCOUNT_DEST to vault in secret/$PROJECT/$SERVICE_ACCOUNT_NAME"
+            vault write secret/"$PROJECT"/"$SERVICE_ACCOUNT_NAME" "$PROJECT"=@"$SERVICE_ACCOUNT_DEST"
+        else
+            echoerr "key already exists in vault for $SERVICE_ACCOUNT_NAME so no need to create it again"
+            echo "$EXISTING_KEY" > "$SERVICE_ACCOUNT_DEST"
+        fi
+    else
+        echoerr "Unable to create and save key for service account $SERVICE_ACCOUNT_NAME because it doesn't appear to exist"
+        exit 1
+    fi
+}
+
 echo "-----------------------------------------------------------------------------"
 CURR_PROJ=$(gcloud config list --format 'value(core.project)' 2>/dev/null)
 echo " *****   Current gcloud project is : $CURR_PROJ"
@@ -287,6 +383,7 @@ do
         echo "-----------------------------------------------------------------------------"
         echo "Managed DNS Google Cloud Project selected : $dns_project"
         terraform_variable "managed_dns_gcp_project" "$dns_project" "$GIT_ROOT_DIR" "spinnaker" "$PROJECT"
+        terraform_variable "managed_dns_gcp_project" "$dns_project" "$GIT_ROOT_DIR" "halyard" "$PROJECT"
         terraform_variable "gcp_project" "$dns_project" "$GIT_ROOT_DIR" "dns" "$PROJECT"
         vault write "secret/$PROJECT/dns_project_name" "value=$dns_project" >/dev/null 2>&1
         break;
@@ -457,8 +554,6 @@ terraform_variable "gcp_admin_email" "$gcp_admin_email" "$GIT_ROOT_DIR" "halyard
 terraform_variable "spingo_user_email" "$USER_EMAIL" "$GIT_ROOT_DIR" "spinnaker" "$PROJECT"
 terraform_variable "spingo_user_email" "$USER_EMAIL" "$GIT_ROOT_DIR" "halyard" "$PROJECT"
 
-
-
 echo "Enabling required Google Cloud APIs. This could take several minutes."
 echo "enabling iam.googleapis.com service"
 gcloud services enable iam.googleapis.com
@@ -478,26 +573,6 @@ echo "enabling cloudkms.googleapis.com - Needed for Vault"
 gcloud services enable cloudkms.googleapis.com
 
 echo "creating $SERVICE_ACCOUNT_NAME service account"
-SA_EMAIL="$(gcloud iam service-accounts list \
-      --filter="displayName:${SERVICE_ACCOUNT_NAME}" \
-      --format='value(email)')"
-if [ -n "$SA_EMAIL" ]; then
-    echo "Service account $SERVICE_ACCOUNT_NAME already exists so no need to create it"
-else
-    gcloud iam service-accounts create \
-        "$SERVICE_ACCOUNT_NAME" \
-        --display-name "$SERVICE_ACCOUNT_NAME"
-fi
-
-while [ -z "$SA_EMAIL" ]; do
-  echo "waiting for service account to be fully created..."
-  sleep 1
-  SA_EMAIL="$(gcloud iam service-accounts list \
-      --filter="displayName:${SERVICE_ACCOUNT_NAME}" \
-      --format='value(email)')"
-done
-
-echo "adding roles to $SERVICE_ACCOUNT_NAME for $SA_EMAIL"
 
 roles=(
     'roles/storage.admin'
@@ -515,50 +590,29 @@ roles=(
     'roles/pubsub.admin'
     'roles/cloudkms.admin'
 )
-
-EXISTING_ROLES="$(gcloud projects get-iam-policy "$PROJECT" --flatten="bindings[].members" --format="json" --filter="bindings.members:$SA_EMAIL" | jq -r '.[].bindings' | jq -s '.')"
-
-for role in "${roles[@]}"; do
-    EXISTING_ROLE_CHECK="$(echo "$EXISTING_ROLES" | jq -r --arg rl "$role" '.[] | select(.role == $rl) | .role')"
-    if [ -z "$EXISTING_ROLE_CHECK" ]; then
-        echo "Attempting to add role $role to service account $SERVICE_ACCOUNT_NAME"
-        
-        if gcloud --no-user-output-enabled projects add-iam-policy-binding "$PROJECT" \
-            --member serviceAccount:"$SA_EMAIL" \
-            --role="$role"; then
-            echo "Added role $role to service account $SERVICE_ACCOUNT_NAME"
-        else
-            echo "Unable to add role $role to service account $SERVICE_ACCOUNT_NAME"
-        fi
-    else
-        echo "Role $role already exists on service account $SERVICE_ACCOUNT_NAME so nothing to add"
-    fi
-done
-
-EXISTING_KEY="$(vault read -field="$PROJECT" "secret/$PROJECT/$SERVICE_ACCOUNT_NAME")"
-if [ -z "$EXISTING_KEY" ]; then
-    echo "generating keys for $SERVICE_ACCOUNT_NAME"
-    gcloud iam service-accounts keys create "$SERVICE_ACCOUNT_DEST" \
-        --iam-account "$SA_EMAIL"
-    echo "writing $SERVICE_ACCOUNT_DEST to vault in secret/$PROJECT/$SERVICE_ACCOUNT_NAME"
-    vault write secret/"$PROJECT"/"$SERVICE_ACCOUNT_NAME" "$PROJECT"=@${SERVICE_ACCOUNT_DEST}
-else
-    echo "key already exists in vault for $SERVICE_ACCOUNT_NAME so no need to create it again"
-    echo "$EXISTING_KEY" > "$SERVICE_ACCOUNT_DEST"
-fi
+create_service_account "$SERVICE_ACCOUNT_NAME"
+add_roles_to_service_account "$SERVICE_ACCOUNT_NAME" roles
+create_and_save_service_account_key "$SERVICE_ACCOUNT_NAME" "$SERVICE_ACCOUNT_DEST" "$PROJECT"
 
 cp "$SERVICE_ACCOUNT_DEST" ./spinnaker
 cp "$SERVICE_ACCOUNT_DEST" ./halyard
 cp "$SERVICE_ACCOUNT_DEST" ./dns
 
 if [ "$PROJECT" != "$dns_project" ]; then
-    echo "Using a seperate DNS project so getting service account JSON for the $dns_project project from the vault secret/$dns_project/terraform-account"
+    echoerr "Using a seperate DNS project so getting service account JSON for the $dns_project project from the vault secret/$dns_project/terraform-account"
     if [ -f dns/terraform-account-dns.json ]; then
         rm dns/terraform-account-dns.json
     fi
     vault read -field="$dns_project" secret/"$dns_project"/terraform-account > dns/terraform-account-dns.json
-    terraform_variable "dns_gcp_project" "$dns_project" "$GIT_ROOT_DIR" "halyard" "$PROJECT"
     cp dns/terraform-account-dns.json spinnaker/
+else
+    echoerr "Using Cloud DNS inside this project so creating Let's Encrypt (certbot) service account to be used by halyard to setup SSL"
+    roles=(
+        'roles/dns.admin'
+    )
+    create_service_account "certbot"
+    add_roles_to_service_account "certbot" roles
+    create_and_save_service_account_key "certbot" "certbot.json" "$PROJECT"
 fi
 
 cp "$SERVICE_ACCOUNT_DEST" ./static_ips

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -591,7 +591,7 @@ roles=(
     'roles/cloudkms.admin'
 )
 create_service_account "$SERVICE_ACCOUNT_NAME"
-add_roles_to_service_account "$SERVICE_ACCOUNT_NAME" roles
+add_roles_to_service_account "$SERVICE_ACCOUNT_NAME" roles "$PROJECT"
 create_and_save_service_account_key "$SERVICE_ACCOUNT_NAME" "$SERVICE_ACCOUNT_DEST" "$PROJECT"
 
 cp "$SERVICE_ACCOUNT_DEST" ./spinnaker
@@ -611,7 +611,7 @@ else
         'roles/dns.admin'
     )
     create_service_account "certbot"
-    add_roles_to_service_account "certbot" roles
+    add_roles_to_service_account "certbot" roles "$PROJECT"
     create_and_save_service_account_key "certbot" "certbot.json" "$PROJECT"
 fi
 

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -213,9 +213,13 @@ add_roles_to_service_account(){
     PROJECT="$3"
     roles=("${!list}")
 
-    SA_EMAIL="$(gcloud iam service-accounts list \
-        --filter="displayName:${SERVICE_ACCOUNT_NAME}" \
-        --format='value(email)')"
+    while [ -z "$SA_EMAIL" ]; do
+        echoerr "waiting for service account to be fully created..."
+        sleep 1
+        SA_EMAIL="$(gcloud iam service-accounts list \
+            --filter="displayName:${SERVICE_ACCOUNT_NAME}" \
+            --format='value(email)')"
+    done
 
     if [ -n "$SA_EMAIL" ]; then
         echoerr "adding roles to $SERVICE_ACCOUNT_NAME for $SA_EMAIL"

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -557,6 +557,7 @@ if [ "$PROJECT" != "$dns_project" ]; then
         rm dns/terraform-account-dns.json
     fi
     vault read -field="$dns_project" secret/"$dns_project"/terraform-account > dns/terraform-account-dns.json
+    terraform_variable "dns_gcp_project" "$dns_project" "$GIT_ROOT_DIR" "halyard" "$PROJECT"
     cp dns/terraform-account-dns.json spinnaker/
 fi
 

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -52,8 +52,7 @@ terraform_override() {
     fi
     vault write "secret/$5/local-override-$2" \
         "value"=@"$3/$4/override.tf" \
-        "vardirectory=$4" \
-        "varname=$2">/dev/null 2>&1
+        "vardirectory=$4" >/dev/null 2>&1
 }
 
 terraform_variable() {

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -61,9 +61,9 @@ terraform_variable() {
     # $3 = git root directory
     # $4 = terraform sub-project directory
     # $5 = GCP project name
-    # $6 = Store as JSON (boolean)
+    # $6 = Secret type or "" for text
     
-    if [ "$6" == "true" ]; then
+    if [ "$6" == "json" ]; then
         # Store as JSON
         SECRET_VALUE="$2"
         JSON_FILE_SUFFIX=".json"
@@ -385,7 +385,7 @@ do
 done
 
 terraform_variable "region" "$CLUSTER_REGION" "$GIT_ROOT_DIR" "static_ips" "$PROJECT"
-terraform_variable "ship_plans" "$SHIP_PLANS_JSON" "$GIT_ROOT_DIR" "static_ips" "$PROJECT" "true"
+terraform_variable "ship_plans" "$SHIP_PLANS_JSON" "$GIT_ROOT_DIR" "static_ips" "$PROJECT" "json"
 
 # choose a zone to place the Halyard VMs into
 echo "-----------------------------------------------------------------------------"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -87,9 +87,9 @@ module "k8s" {
   ]
   k8s_ip_ranges_map = { for s in local.full_ship_plan_keys : s => {
     master_cidr = "172.16.0.0/28"                                     # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
-    pod_cidr    = "1${index(local.full_ship_plan_keys, s)}.60.0.0/14" # The IP address range of the kubernetes pods in this cluster.
-    svc_cidr    = "1${index(local.full_ship_plan_keys, s)}.190.16.0/20"
-    node_cidr   = "1${index(local.full_ship_plan_keys, s)}.190.0.0/22"
+    pod_cidr    = "10.6${index(local.full_ship_plan_keys, s)}.0.0/14" # The IP address range of the kubernetes pods in this cluster.
+    svc_cidr    = "10.19${index(local.full_ship_plan_keys, s)}.16.0/20"
+    node_cidr   = "10.19${index(local.full_ship_plan_keys, s)}.0.0/22"
     }
   }
 }

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -271,7 +271,7 @@ module "vault_setup" {
 resource "google_compute_firewall" "iap" {
   for_each = data.terraform_remote_state.static_ips.outputs.ship_plans
   name     = "${each.key}-cloud-iap-ssh"
-  network  = each.key
+  network  = module.k8s.network_link_map[each.key]
 
   allow {
     protocol = "tcp"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -268,6 +268,21 @@ module "vault_setup" {
   ship_plans           = data.terraform_remote_state.static_ips.outputs.ship_plans
 }
 
+resource "google_compute_firewall" "iap" {
+  for_each = data.terraform_remote_state.static_ips.outputs.ship_plans
+  name     = "${each.key}-cloud-iap-ssh"
+  network  = each.key
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22"]
+  }
+
+  source_ranges = [
+    "35.235.240.0/20"
+  ]
+}
+
 output "spinnaker_onboarding_service_account_email" {
   value = module.spinnaker_onboarding_service_account.service_account_email
 }
@@ -294,6 +309,14 @@ output "vault_yml_files_map" {
 
 output "vault_bucket_name_map" {
   value = module.vault_setup.vault_bucket_name_map
+}
+
+output "halyard_network_name" {
+  value = keys(module.k8s.network_name_map)[0]
+}
+
+output "halyard_subnetwork_name" {
+  value = keys(module.k8s.subnet_name_map)[0]
 }
 
 output "created_onboarding_bucket_name" {

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -57,7 +57,6 @@ data "google_project" "project" {
 
 locals {
   full_ship_plan_keys = concat(keys(module.gke_keys.crypto_key_id_map), formatlist("%s-agent", keys(module.gke_keys.crypto_key_id_map)))
-  node_cidr_pool      = cidrsubnets("10.1.0.0/16", 4, 4, 4, 4, 4, 4, 4, 4)
 }
 
 module "k8s" {

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -87,8 +87,8 @@ module "k8s" {
   ]
   k8s_ip_ranges_map = { for s in local.full_ship_plan_keys : s => {
     master_cidr = "172.16.0.0/28"                                     # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
-    pod_cidr    = "10.6${index(local.full_ship_plan_keys, s)}.0.0/14" # The IP address range of the kubernetes pods in this cluster.
-    svc_cidr    = "10.19${index(local.full_ship_plan_keys, s)}.16.0/20"
+    pod_cidr    = "10.60.0.0/14" # The IP address range of the kubernetes pods in this cluster.
+    svc_cidr    = "10.190.16.0/20"
     node_cidr   = "10.19${index(local.full_ship_plan_keys, s)}.0.0/22"
     }
   }

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -244,6 +244,17 @@ resource "google_service_account_iam_binding" "k8s_sa_workload_identity_binding"
   ]
 }
 
+data "vault_generic_secret" "certbot_account" {
+  path = "secret/${var.gcp_project != var.managed_dns_gcp_project ? var.managed_dns_gcp_project : var.gcp_project}/certbot"
+}
+
+resource "google_storage_bucket_object" "service_account_key_storage" {
+  name         = ".gcp/certbot.json"
+  content      = data.vault_generic_secret.certbot_account.data[var.gcp_project != var.managed_dns_gcp_project ? var.managed_dns_gcp_project : var.gcp_project]
+  bucket       = module.halyard_storage.bucket_name
+  content_type = "application/json"
+}
+
 module "halyard_service_account" {
   source               = "./modules/gcp-service-account"
   service_account_name = "spinnaker-halyard"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -81,6 +81,13 @@ module "k8s" {
     "roles/storage.objectViewer",
     "projects/${var.gcp_project}/roles/${google_project_iam_custom_role.vault_role.role_id}"
   ]
+  k8s_ip_ranges_map = { for k, v in data.terraform_remote_state.static_ips.outputs.ship_plans : k => {
+    master_cidr = "172.16.0.0/28"                                                                           # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
+    pod_cidr    = "1${index(keys(data.terraform_remote_state.static_ips.outputs.ship_plans), k)}.60.0.0/14" # The IP address range of the kubernetes pods in this cluster.
+    svc_cidr    = "1${index(keys(data.terraform_remote_state.static_ips.outputs.ship_plans), k)}.190.16.0/20"
+    node_cidr   = "1${index(keys(data.terraform_remote_state.static_ips.outputs.ship_plans), k)}.190.0.0/22"
+    }
+  }
 }
 
 module "google_managed" {

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -282,18 +282,19 @@ module "vault_keys" {
 }
 
 module "vault_setup" {
-  source               = "./modules/vault"
-  gcp_project          = var.gcp_project
-  kms_keyring_name_map = module.vault_keyring.kms_key_ring_name_map
-  vault_ips_map        = data.terraform_remote_state.static_ips.outputs.vault_ips_map
-  crypto_key_id_map    = module.vault_keys.crypto_key_id_map
-  ship_plans           = data.terraform_remote_state.static_ips.outputs.ship_plans
+  source                    = "./modules/vault"
+  gcp_project               = var.gcp_project
+  kms_keyring_name_map      = module.vault_keyring.kms_key_ring_name_map
+  vault_ips_map             = data.terraform_remote_state.static_ips.outputs.vault_ips_map
+  crypto_key_id_map         = module.vault_keys.crypto_key_id_map
+  ship_plans                = data.terraform_remote_state.static_ips.outputs.ship_plans
+  service_account_email_map = module.k8s.service_account_map
 }
 
 resource "google_compute_firewall" "iap" {
   for_each = data.terraform_remote_state.static_ips.outputs.ship_plans
   name     = "${each.key}-cloud-iap-ssh"
-  network  = each.key
+  network  = module.k8s.network_link_map[each.key]
 
   allow {
     protocol = "tcp"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -57,6 +57,7 @@ data "google_project" "project" {
 
 locals {
   full_ship_plan_keys = concat(keys(module.gke_keys.crypto_key_id_map), formatlist("%s-agent", keys(module.gke_keys.crypto_key_id_map)))
+  pod_cidr_pool = concat(cidrsubnets("10.0.0.0/12", 2, 2, 2, 2), cidrsubnets("172.16.0.0/12", 2, 2, 2, 2))
 }
 
 module "k8s" {
@@ -87,7 +88,7 @@ module "k8s" {
   ]
   k8s_ip_ranges_map = { for s in local.full_ship_plan_keys : s => {
     master_cidr = "172.16.0.0/28" # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
-    pod_cidr    = "1${index(local.full_ship_plan_keys, s)}.60.0.0/14"  # The IP address range of the kubernetes pods in this cluster.
+    pod_cidr    = local.pod_cidr_pool[index(local.full_ship_plan_keys, s)]  # The IP address range of the kubernetes pods in this cluster.
     svc_cidr    = "10.19${index(local.full_ship_plan_keys, s)}.16.0/20"
     node_cidr   = "10.19${index(local.full_ship_plan_keys, s)}.0.0/22"
     }

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -87,7 +87,7 @@ module "k8s" {
   ]
   k8s_ip_ranges_map = { for s in local.full_ship_plan_keys : s => {
     master_cidr = "172.16.0.0/28" # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
-    pod_cidr    = "10.60.0.0/14"  # The IP address range of the kubernetes pods in this cluster.
+    pod_cidr    = "1${index(local.full_ship_plan_keys, s)}.60.0.0/14"  # The IP address range of the kubernetes pods in this cluster.
     svc_cidr    = "10.19${index(local.full_ship_plan_keys, s)}.16.0/20"
     node_cidr   = "10.19${index(local.full_ship_plan_keys, s)}.0.0/22"
     }

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -79,7 +79,6 @@ module "k8s" {
     "roles/monitoring.metricWriter",
     "roles/monitoring.viewer",
     "roles/storage.objectViewer",
-    "roles/compute.viewer",
     "projects/${var.gcp_project}/roles/${google_project_iam_custom_role.vault_role.role_id}"
   ]
 }
@@ -176,7 +175,6 @@ resource "google_project_iam_custom_role" "vault_role" {
     "iam.serviceAccountKeys.get",
     "compute.instances.get",
     "compute.instanceGroups.list",
-    "compute.instanceGroups.listInstances",
   ]
 }
 

--- a/spinnaker/modules/dns/dns.tf
+++ b/spinnaker/modules/dns/dns.tf
@@ -7,7 +7,6 @@ it did.
 reference: https://www.terraform.io/docs/providers/google/r/dns_record_set.html
 */
 resource "google_dns_record_set" "ui" {
-  # see the vars file to an explination about this count thing
   for_each     = var.ship_plans
   name         = "${each.value["deckSubdomain"]}${length(each.value["deckSubdomain"]) > 0 ? "." : ""}${each.value["wildcardDomain"]}."
   type         = "A"
@@ -17,7 +16,6 @@ resource "google_dns_record_set" "ui" {
 }
 
 resource "google_dns_record_set" "api" {
-  # see the vars file to an explination about this count thing
   for_each     = var.ship_plans
   name         = "${each.value["gateSubdomain"]}.${each.value["wildcardDomain"]}."
   type         = "A"
@@ -27,7 +25,6 @@ resource "google_dns_record_set" "api" {
 }
 
 resource "google_dns_record_set" "api_x509" {
-  # see the vars file to an explination about this count thing
   for_each     = var.ship_plans
   name         = "${each.value["x509Subdomain"]}.${each.value["wildcardDomain"]}."
   type         = "A"
@@ -37,7 +34,6 @@ resource "google_dns_record_set" "api_x509" {
 }
 
 resource "google_dns_record_set" "vault" {
-  # see the vars file to an explination about this count thing
   for_each     = var.ship_plans
   name         = "${each.value["vaultSubdomain"]}.${each.value["wildcardDomain"]}."
   type         = "A"

--- a/spinnaker/modules/k8s/tf-gke.tf
+++ b/spinnaker/modules/k8s/tf-gke.tf
@@ -29,7 +29,7 @@ resource "google_container_cluster" "cluster" {
   workload_identity_config {
     identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"
   }
-  cluster_ipv4_cidr           = var.k8s_ip_ranges["pod_cidr"]
+  cluster_ipv4_cidr           = var.k8s_ip_ranges_map[each.key]["pod_cidr"]
   description                 = var.description
   enable_binary_authorization = var.k8s_options["binary_authorization"]
   enable_kubernetes_alpha     = var.extras["kubernetes_alpha"]
@@ -120,7 +120,7 @@ resource "google_container_cluster" "cluster" {
     for_each = local.private_cluster
     content {
       enable_private_nodes   = var.private_cluster
-      master_ipv4_cidr_block = var.k8s_ip_ranges["master_cidr"]
+      master_ipv4_cidr_block = var.k8s_ip_ranges_map[each.key]["master_cidr"]
     }
   }
 

--- a/spinnaker/modules/k8s/tf-main.tf
+++ b/spinnaker/modules/k8s/tf-main.tf
@@ -25,18 +25,18 @@ resource "google_compute_subnetwork" "subnet" {
   network                  = google_compute_network.vpc[each.key].name # https://github.com/terraform-providers/terraform-provider-google/issues/1792
   region                   = each.value["clusterRegion"]
   description              = var.description
-  ip_cidr_range            = var.k8s_ip_ranges["node_cidr"]
+  ip_cidr_range            = var.k8s_ip_ranges_map[each.key]["node_cidr"]
   private_ip_google_access = true
 
   # enable_flow_logs = "${var.enable_flow_logs}" # TODO
   secondary_ip_range {
     range_name    = "${each.key}-k8s-pod"
-    ip_cidr_range = var.k8s_ip_ranges["pod_cidr"]
+    ip_cidr_range = var.k8s_ip_ranges_map[each.key]["pod_cidr"]
   }
 
   secondary_ip_range {
     range_name    = "${each.key}-k8s-svc"
-    ip_cidr_range = var.k8s_ip_ranges["svc_cidr"]
+    ip_cidr_range = var.k8s_ip_ranges_map[each.key]["svc_cidr"]
   }
 }
 

--- a/spinnaker/modules/k8s/variables-maps.tf
+++ b/spinnaker/modules/k8s/variables-maps.tf
@@ -12,6 +12,11 @@ variable "k8s_ip_ranges" {
   }
 }
 
+variable "k8s_ip_ranges_map" {
+  type        = map(map(string))
+  description = "See recommended IP range sizing: https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips#defaults_limits"
+}
+
 # Map: K8s Control Plane Options
 ###############################
 variable "k8s_options" {

--- a/spinnaker/modules/vault/vars.tf
+++ b/spinnaker/modules/vault/vars.tf
@@ -20,3 +20,7 @@ variable "ship_plans" {
   type        = map(map(string))
   description = "The object that describes all of the clusters that need to be built by Spingo"
 }
+
+variable "service_account_email_map" {
+  type = map(map(string))
+}

--- a/spinnaker/modules/vault/vars.tf
+++ b/spinnaker/modules/vault/vars.tf
@@ -22,5 +22,5 @@ variable "ship_plans" {
 }
 
 variable "service_account_email_map" {
-  type = map(map(string))
+  type = map(string)
 }

--- a/spinnaker/modules/vault/vault.tf
+++ b/spinnaker/modules/vault/vault.tf
@@ -24,14 +24,14 @@ resource "google_storage_bucket_iam_member" "vault_server" {
   for_each = var.ship_plans
   bucket   = google_storage_bucket.vault[each.key].name
   role     = "roles/storage.objectAdmin"
-  member   = "serviceAccount:${each.key}@${var.gcp_project}.iam.gserviceaccount.com"
+  member   = var.service_account_email_map[each.key]
 }
 
 resource "google_kms_crypto_key_iam_member" "vault_init" {
   for_each      = var.ship_plans
   crypto_key_id = lookup(var.crypto_key_id_map, each.key, "")
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${each.key}@${var.gcp_project}.iam.gserviceaccount.com"
+  member        = var.service_account_email_map[each.key]
 }
 
 # Render the YAML file

--- a/spinnaker/modules/vault/vault.tf
+++ b/spinnaker/modules/vault/vault.tf
@@ -24,14 +24,14 @@ resource "google_storage_bucket_iam_member" "vault_server" {
   for_each = var.ship_plans
   bucket   = google_storage_bucket.vault[each.key].name
   role     = "roles/storage.objectAdmin"
-  member   = var.service_account_email_map[each.key]
+  member   = "serviceAccount:${var.service_account_email_map[each.key]}"
 }
 
 resource "google_kms_crypto_key_iam_member" "vault_init" {
   for_each      = var.ship_plans
   crypto_key_id = lookup(var.crypto_key_id_map, each.key, "")
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = var.service_account_email_map[each.key]
+  member        = "serviceAccount:${var.service_account_email_map[each.key]}"
 }
 
 # Render the YAML file

--- a/spinnaker/modules/vault/vault.tf
+++ b/spinnaker/modules/vault/vault.tf
@@ -45,7 +45,7 @@ data "template_file" "vault" {
     kms_crypto_key   = "vault_key_${each.key}"
     crypto_key_id    = lookup(var.crypto_key_id_map, each.key, "")
     project          = var.gcp_project
-    cluster_sa_email = "${each.key}@${var.gcp_project}.iam.gserviceaccount.com"
+    cluster_sa_email = var.service_account_email_map[each.key]
     cluster_region   = each.value["clusterRegion"]
     load_balancer_ip = lookup(var.vault_ips_map, each.key, "")
   }


### PR DESCRIPTION
- Automatic DNS import when Cloud DNS is set up in another project
- Automatic creation of certbot service account for when no TF will run but the project will host the Cloud DNS managed zone
- Warning to the user that keystore input will be entered by automation
- Place halyard within one of the created vpc networks and subnets
- Automatically add a firewall rule for IAP tunnel to the halyard VM
- Automatic storage and retrieval of terraform variables based on what is actually in the infrastructure vault instead of relying on manual code updates in the `scripts/restore_saved_config_from_vault.sh` script
- Automatic custom project vault role `vault-gcp-role` to allow vault service account to validate GCE metadata authentication
- Add new project role `vault-gcp-role` to each cluster service account
- Made `beforepush.sh` volume mount read-only