### PR TITLE
Fixed vault agent injector rule to fit firewall naming rules

### DIFF
--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -320,7 +320,7 @@ resource "google_compute_firewall" "iap" {
 
 resource "google_compute_firewall" "vault_agent_injector" {
   for_each = data.terraform_remote_state.static_ips.outputs.ship_plans
-  name     = "${each.key}-vault_agent_injector"
+  name     = "${each.key}-vault-agent-injector"
   network  = module.k8s.network_link_map[each.key]
 
   allow {


### PR DESCRIPTION
This broke because firewall rules can't have underscores in them, or at least terraform won't let them.