### PR TITLE
Vault Kubernetes auth path

### DIFF
--- a/halyard/halScripts/setup_kubernetes_dynamic.sh
+++ b/halyard/halScripts/setup_kubernetes_dynamic.sh
@@ -142,7 +142,7 @@ kubectl --kubeconfig="$CONFIG_FILE" annotate serviceaccount -n spinnaker spinnak
     iam.gke.io/gcp-service-account=${ONBOARDING_SA_EMAIL}
 
 if [[ ${deployment} == *-agent ]]; then
-    echo "Creating spinnaker configmap with vault address"
+    echo "Creating spinnaker configmap with vault address and auth path"
     cat <<SPINNAKER_CONFIGMAP_AGENT | kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker apply -f -
     apiVersion: v1
     data:
@@ -155,11 +155,12 @@ if [[ ${deployment} == *-agent ]]; then
 SPINNAKER_CONFIGMAP_AGENT
     echo "No need to create instance cloudsql secret for agent cluster"
 else
+    echo "Creating spinnaker configmap with vault address and auth path"
     cat <<SPINNAKER_CONFIGMAP | kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker apply -f -
     apiVersion: v1
     data:
-      VAULT_ADDR: https://${VAULT_ADDR[deployment]}
-      VAULT_AUTH_PATH: auth/kubernetes-${deployment}/login
+      VAULT_ADDR: https://${VAULT_ADDR[replace(deployment, "-agent", "")]}
+      VAULT_AUTH_PATH: auth/kubernetes-${replace(deployment, "-agent", "")}/login
     kind: ConfigMap
     metadata:
       name: spinnaker-config

--- a/halyard/halScripts/setup_kubernetes_dynamic.sh
+++ b/halyard/halScripts/setup_kubernetes_dynamic.sh
@@ -141,20 +141,30 @@ kubectl --kubeconfig="$CONFIG_FILE" create serviceaccount -n spinnaker spinnaker
 kubectl --kubeconfig="$CONFIG_FILE" annotate serviceaccount -n spinnaker spinnaker-onboarding \
     iam.gke.io/gcp-service-account=${ONBOARDING_SA_EMAIL}
 
-echo "Creating spinnaker configmap with vault address"
-cat <<SPINNAKER_CONFIGMAP | kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker apply -f -
-apiVersion: v1
-data:
-  VAULT_ADDR: https://${VAULT_ADDR[replace(deployment, "-agent", "")]}
-kind: ConfigMap
-metadata:
-  name: spinnaker-config
-  namespace: spinnaker
-SPINNAKER_CONFIGMAP
-
 if [[ ${deployment} == *-agent ]]; then
+    echo "Creating spinnaker configmap with vault address"
+    cat <<SPINNAKER_CONFIGMAP_AGENT | kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker apply -f -
+    apiVersion: v1
+    data:
+      VAULT_ADDR: https://${VAULT_ADDR[replace(deployment, "-agent", "")]}
+      VAULT_AUTH_PATH: auth/kubernetes-${deployment}/login
+    kind: ConfigMap
+    metadata:
+      name: spinnaker-config
+      namespace: spinnaker
+SPINNAKER_CONFIGMAP_AGENT
     echo "No need to create instance cloudsql secret for agent cluster"
 else
+    cat <<SPINNAKER_CONFIGMAP | kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker apply -f -
+    apiVersion: v1
+    data:
+      VAULT_ADDR: https://${VAULT_ADDR[deployment]}
+      VAULT_AUTH_PATH: auth/kubernetes-${deployment}/login
+    kind: ConfigMap
+    metadata:
+      name: spinnaker-config
+      namespace: spinnaker
+SPINNAKER_CONFIGMAP
     echo "Creating Spinnaker namespace and cloudsql-instance-credentials secret"
     kubectl --kubeconfig="$CONFIG_FILE" -n spinnaker create secret generic cloudsql-instance-credentials --from-file=/${USER}/.gcp/secret
     kubectl --kubeconfig="$CONFIG_FILE" create serviceaccount -n spinnaker ${deployment}

--- a/halyard/halyard.tf
+++ b/halyard/halyard.tf
@@ -58,7 +58,7 @@ data "template_file" "vault" {
     SETUP_VAULT_CONTENTS = templatefile("./halScripts/setup_vault_dynamic.sh", {
       deployments = { for k, v in data.terraform_remote_state.static_ips.outputs.ship_plans : k => {
         vaultYaml           = data.terraform_remote_state.spinnaker.outputs.vault_yml_files_map[k]
-        clusterName         = v["clusterPrefix"]
+        clusterName         = "${k}"
         clusterRegion       = v["clusterRegion"]
         vaultLoadBalancerIP = data.terraform_remote_state.static_ips.outputs.vault_ips_map[k]
         kubeConfig          = "/${var.service_account_name}/.kube/${k}.config"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -221,7 +221,10 @@ module "spinnaker_onboarding_service_account" {
   service_account_prefix = ""
   bucket_name            = module.halyard_storage.bucket_name
   gcp_project            = var.gcp_project
-  roles                  = ["roles/container.admin"]
+  roles                  = [
+    "roles/container.admin", 
+    "roles/iam.serviceAccountTokenCreator"
+  ]
   create_and_store_key   = false
 }
 


### PR DESCRIPTION
The vault kubernetes auth paths were created with just the cluster prefix name:

    auth/kubernetes-sandbox/login

instead of:

    auth/kubernetes-sandbox-us-central1/login