### PR TITLE
Removes 'agent' VPC

### DIFF
--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -87,7 +87,7 @@ module "k8s" {
     "projects/${var.gcp_project}/roles/${google_project_iam_custom_role.vault_role.role_id}"
   ]
   k8s_ip_ranges_map = { for s in local.full_ship_plan_keys : s => {
-    master_cidr = "172.16.${index(local.full_ship_plan_keys, s)}.0/28"
+    master_cidr = "172.16.${index(local.full_ship_plan_keys, s)}.0/28"     # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
     pod_cidr    = local.pod_cidr_pool[index(local.full_ship_plan_keys, s)] # The IP address range of the kubernetes pods in this cluster.
     svc_cidr    = "10.19${index(local.full_ship_plan_keys, s)}.16.0/20"
     node_cidr   = "10.19${index(local.full_ship_plan_keys, s)}.0.0/22"

--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -87,7 +87,7 @@ module "k8s" {
     "projects/${var.gcp_project}/roles/${google_project_iam_custom_role.vault_role.role_id}"
   ]
   k8s_ip_ranges_map = { for s in local.full_ship_plan_keys : s => {
-    master_cidr = var.k8s_ip_ranges["master_cidr"]                         # Specifies a private RFC1918 block for the master's VPC. The master range must not overlap with any subnet in your cluster's VPC. The master and your cluster use VPC peering. Must be specified in CIDR notation and must be /28 subnet. See: https://www.terraform.io/docs/providers/google/r/container_cluster.html#master_ipv4_cidr_block 10.0.82.0/28
+    master_cidr = "172.16.${index(local.full_ship_plan_keys, s)}.0/28"
     pod_cidr    = local.pod_cidr_pool[index(local.full_ship_plan_keys, s)] # The IP address range of the kubernetes pods in this cluster.
     svc_cidr    = "10.19${index(local.full_ship_plan_keys, s)}.16.0/20"
     node_cidr   = "10.19${index(local.full_ship_plan_keys, s)}.0.0/22"

--- a/spinnaker/modules/k8s/outputs.tf
+++ b/spinnaker/modules/k8s/outputs.tf
@@ -26,11 +26,11 @@ output "client_key_map" {
 }
 
 output "network_name_map" {
-  value = { for k, v in var.ship_plans : k => google_compute_network.vpc[k].name }
+  value = { for k, v in var.ship_plans_without_agent : k => google_compute_network.vpc[k].name }
 }
 
 output "network_link_map" {
-  value = { for k, v in var.ship_plans : k => google_compute_network.vpc[k].self_link }
+  value = { for k, v in var.ship_plans_without_agent : k => google_compute_network.vpc[k].self_link }
 }
 
 output "subnet_name_map" {

--- a/spinnaker/modules/k8s/tf-gke.tf
+++ b/spinnaker/modules/k8s/tf-gke.tf
@@ -24,7 +24,7 @@ resource "google_container_cluster" "cluster" {
   name       = each.key
   project    = var.project
   location   = each.value["clusterRegion"]
-  network    = google_compute_network.vpc[each.key].name # https://github.com/terraform-providers/terraform-provider-google/issues/1792
+  network    = google_compute_network.vpc[replace(each.key, "-agent", "")].name # https://github.com/terraform-providers/terraform-provider-google/issues/1792
   subnetwork = google_compute_subnetwork.subnet[each.key].self_link
   workload_identity_config {
     identity_namespace = "${data.google_project.project.project_id}.svc.id.goog"

--- a/spinnaker/modules/k8s/tf-main.tf
+++ b/spinnaker/modules/k8s/tf-main.tf
@@ -10,7 +10,7 @@ data "google_client_config" "gcloud" {
 # VPCs
 ##########################################################
 resource "google_compute_network" "vpc" {
-  for_each                = var.ship_plans
+  for_each                = var.ship_plans_without_agent
   name                    = each.key
   project                 = var.project
   auto_create_subnetworks = "false"
@@ -22,7 +22,7 @@ resource "google_compute_subnetwork" "subnet" {
   for_each                 = var.ship_plans
   name                     = each.key
   project                  = var.project
-  network                  = google_compute_network.vpc[each.key].name # https://github.com/terraform-providers/terraform-provider-google/issues/1792
+  network                  = google_compute_network.vpc[replace(each.key, "-agent", "")].name # https://github.com/terraform-providers/terraform-provider-google/issues/1792
   region                   = each.value["clusterRegion"]
   description              = var.description
   ip_cidr_range            = var.k8s_ip_ranges_map[each.key]["node_cidr"]

--- a/spinnaker/modules/k8s/tf-nat.tf
+++ b/spinnaker/modules/k8s/tf-nat.tf
@@ -37,7 +37,18 @@ resource "google_compute_router_nat" "nat" {
       "${each.key}-k8s-svc",
     ]
   }
+
+  subnetwork {
+    name                    = google_compute_subnetwork.subnet["${each.key}-agent"].self_link
+    source_ip_ranges_to_nat = ["PRIMARY_IP_RANGE", "LIST_OF_SECONDARY_IP_RANGES"]
+
+    secondary_ip_range_names = [
+      "${each.key}-agent-k8s-pod",
+      "${each.key}-agent-k8s-svc",
+    ]
+  }
 }
+
 
 # For old version of NAT Gateway (VM)
 # Route traffic to the Masters through the default gateway. This fixes things like kubectl exec and logs


### PR DESCRIPTION
Removes the agent cluster VPC and moves subnets underneath main cluster VPC in order to egress through the one Cloud NAT
