### PR TITLE
added helm init before attempting to helm install

### DIFF
--- a/halyard/hal-scripts/setup-monitoring-content.sh
+++ b/halyard/hal-scripts/setup-monitoring-content.sh
@@ -91,7 +91,11 @@ echo "deploying metric-enabled spinnaker"
 
 hal deploy apply
 
+
 echo "Starting up prometheus-operator through helm for deployment ${deployment}"
+
+helm init
+
 helm install \
     --name spin \
     --namespace monitoring \

--- a/halyard/hal-scripts/setup-monitoring-content.sh
+++ b/halyard/hal-scripts/setup-monitoring-content.sh
@@ -94,7 +94,11 @@ hal deploy apply
 
 echo "Starting up prometheus-operator through helm for deployment ${deployment}"
 
-helm init
+
+helm init \
+    --service-account tiller \
+    --kubeconfig "${details.kubeConfig}" \
+    --history-max 200
 
 helm install \
     --name spin \


### PR DESCRIPTION
this script was written with the assumption that helm would have already been init'ed prior to running it. This is not necessarily the case. Helm init is now before the helm install command.