### PR TITLE
Grafana admin pw

### DIFF
--- a/spinnaker/modules/metrics/metrics.tf
+++ b/spinnaker/modules/metrics/metrics.tf
@@ -18,7 +18,7 @@ data "template_file" "values" {
     gf_auth_google_client_id     = data.vault_generic_secret.gcp-oauth.data["client-id"]
     gf_auth_google_client_secret = data.vault_generic_secret.gcp-oauth.data["client-secret"]
     gf_cloud_dns_hostname        = trimsuffix(var.cloud_dns_hostname, ".")
-    gf_admin_pw                  = random_password.password.result
+    gf_admin_password            = random_password.password.result
   }
 }
 

--- a/spinnaker/modules/metrics/metrics.tf
+++ b/spinnaker/modules/metrics/metrics.tf
@@ -2,6 +2,12 @@ data "vault_generic_secret" "gcp-oauth" {
   path = "secret/${var.gcp_project}/gcp-oauth"
 }
 
+resource "random_password" "password" {
+  length = 16
+  special = true
+  override_special = "_%@"
+}
+
 # Render the YAML file
 data "template_file" "values" {
   for_each = var.ship_plans
@@ -12,6 +18,7 @@ data "template_file" "values" {
     gf_auth_google_client_id     = data.vault_generic_secret.gcp-oauth.data["client-id"]
     gf_auth_google_client_secret = data.vault_generic_secret.gcp-oauth.data["client-secret"]
     gf_cloud_dns_hostname        = trimsuffix(var.cloud_dns_hostname, ".")
+    gf_admin_pw                  = random_password.password.result
   }
 }
 

--- a/spinnaker/modules/metrics/metrics.yaml
+++ b/spinnaker/modules/metrics/metrics.yaml
@@ -1,4 +1,5 @@
 grafana:
+  adminPassowd: ${gf_admin_password}
   livenessProbe:
     # This is necessary because the liveness probe only uses http by default.
     httpGet:


### PR DESCRIPTION
currently the grafana admin password is set to the default, and changes do not persist. this solves that problem by generating a random one. it can be retrieved by looking in the secret or looking at the generated helm-values.yaml