### PR TITLE
add namespace selector for vault injector

### DIFF
--- a/spinnaker/modules/vault/vault.yaml
+++ b/spinnaker/modules/vault/vault.yaml
@@ -7,6 +7,9 @@ injector:
     tag: "0.1.1"
   agentImage:
     tag: "1.3.1"
+  namespaceSelector:
+     matchLabels:
+       sidecar-injector: enabled
 
 ui:
   enabled: true


### PR DESCRIPTION
This will fix the injector mucking with kubernetes namespaces that we don't want it to (i.e. `kube-system`).

In order to have pod inside a namespace pass through the mutating webhook the namespace the pod is deployed to must have the label `sidecar-injector=enabled`.