### PR TITLE
bump vault helm chart to 040

### DIFF
--- a/halyard/scripts/setup-vault-contents.sh
+++ b/halyard/scripts/setup-vault-contents.sh
@@ -31,7 +31,7 @@ helm install \
     --namespace vault \
     --kubeconfig "${details.kubeConfig}" \
     --values /${USER}/vault/vault_${details.clusterName}_helm_values.yml \
-    https://github.com/hashicorp/vault-helm/archive/v0.3.3.tar.gz
+    https://github.com/hashicorp/vault-helm/archive/v0.4.0.tar.gz
 
 echo "Waiting for vault to be installed for deployment ${deployment}"
 n=0


### PR DESCRIPTION
bump vault helm chart to version 0.4.0
this makes it work instead of not working, which is bad. 
the old helm chart version doesn't work with helm3