### PR TITLE
Vault injector agent firewall rule

### DIFF
--- a/spinnaker/main.tf
+++ b/spinnaker/main.tf
@@ -352,7 +352,8 @@ resource "google_compute_firewall" "vault_agent_injector" {
   }
 
   source_ranges = [
-    var.k8s_ip_ranges["master_cidr"]
+    module.k8s.master_ipv4_cidr_block_map[each.key],
+    module.k8s.master_ipv4_cidr_block_map["${each.key}-agent"]
   ]
 
   target_tags = [

--- a/spinnaker/modules/k8s/outputs.tf
+++ b/spinnaker/modules/k8s/outputs.tf
@@ -60,3 +60,8 @@ output "cloud_nat_adddress_map" {
 output "created_nodepool_map" {
   value = { for k, v in var.ship_plans : k => google_container_node_pool.primary_pool[k] }
 }
+
+output "master_ipv4_cidr_block_map" {
+  value = { for k, v in var.ship_plans : k => google_container_cluster.cluster[k].private_cluster_config[0].master_ipv4_cidr_block }
+}
+

--- a/spinnaker/modules/k8s/tf-nat.tf
+++ b/spinnaker/modules/k8s/tf-nat.tf
@@ -28,6 +28,11 @@ resource "google_compute_router_nat" "nat" {
   nat_ips                            = [data.google_compute_address.existing_nat[each.key].self_link]
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
+  log_config {
+    enable = false
+    filter = "ALL"
+  }
+
   subnetwork {
     name                    = google_compute_subnetwork.subnet[each.key].self_link
     source_ip_ranges_to_nat = ["PRIMARY_IP_RANGE", "LIST_OF_SECONDARY_IP_RANGES"]


### PR DESCRIPTION
- Adds agent cluster's master cidr block to the firewall rule for the vault-agent-injector
- Sets `log_config` on nat resource to value created by google when none was originally supplied to stop terraform from seeing it as a difference